### PR TITLE
Fixes #2993: For syslog-ng and rsyslogd, only send rudder logs to server...

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -305,7 +305,7 @@ bundle agent check_log_system {
 	"syslog_ng_conf_suffix" string => "\" port (&SYSLOGPORT&));};log {source(src);filter(f_local_rudder);destination(loghost);";
 	"syslog_ng_conf_final"  string => "flags(final);};";
 	"syslog_ng_conf"        string => concat("$(syslog_conf_comment)", "$(syslog_ng_conf_prefix)", "$(server_info.cfserved)", "$(syslog_ng_conf_suffix)", "$(syslog_ng_conf_final)");
-	"syslog_ng_conf_regex"  string => concat(escape("$(syslog_ng_conf_prefix)"), "[^\"]+", escape("$(syslog_ng_conf_suffix)"), escape("};"));
+	"syslog_ng_conf_regex"  string => concat(escape("$(syslog_ng_conf_prefix)"), "[^\"]+", escape("$(syslog_ng_conf_suffix)"), ".*");
 
   classes:
 


### PR DESCRIPTION
Hello, this is a fix to the local syslog file cluttering on nodes due to Rudder duplicating informations sent to the server on it.

To be merged in the 2.4 Rudder Techniques branch if possible.
