### PR TITLE
Fixes #2642 : add a warning message if the node cannot connect to the server

### DIFF
--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -144,6 +144,7 @@ bundle agent update {
   			    
   			no_update::
   				"@@Common@@result_error@@hasPolicyServer-root@@common-root@@00@@Update@@None@@$(g.execRun)##$(g.uuid)@#Cannot update node's policy (CFEngine promises)";
+
 			rudder_dependencies_update_error::
 				"@@Common@@result_error@@hasPolicyServer-root@@common-root@@00@@Update@@None@@$(g.execRun)##$(g.uuid)@#Cannot update dependencies";
 
@@ -158,6 +159,14 @@ bundle agent update {
 
 			config|rudder_dependencies_updated|server_ok|executor_ok::
 				"@@Common@@result_repaired@@hasPolicyServer-root@@common-root@@00@@Update@@None@@$(g.execRun)##$(g.uuid)@#Policy or dependencies were updated or CFEngine service restarted";
+
+
+			no_update::
+				"*********************************************************************************
+* rudder-agent could not get an updated configuration from the policy server.   *
+* This can be caused by a network issue, an unavailable server, or if this      *
+* node has not yet been accepted in the Rudder root server.                     *
+*********************************************************************************";
 }
 
 

--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -110,6 +110,13 @@ bundle agent endExecution {
   reports:
    linux|windows::
        "@@Common@@log_info@@hasPolicyServer-root@@common-root@@00@@common@@EndRun@@$(g.execRun)##$(g.uuid)@#End execution";
+
+   no_update::
+	"*********************************************************************************
+* rudder-agent could not get an updated configuration from the policy server.   *
+* This can be caused by a network issue, an unavailable server, or if this      *
+* node has not yet been accepted in the Rudder root server.                     *
+*********************************************************************************";
 }
 
 ##########################################################

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -83,6 +83,14 @@ bundle agent endExecution {
   reports:
 	linux|windows::
 		"@@Common@@log_info@@&TRACKINGKEY&@@common@@EndRun@@$(g.execRun)##$(g.uuid)@#End execution";
+
+	no_update::
+		"*********************************************************************************
+* rudder-agent could not get an updated configuration from the policy server.   *
+* This can be caused by a network issue, an unavailable server, or if this      *
+* node was deleted from the Rudder root server.                                 *
+* Any existing configuration policy will continue to be applied without change. *
+*********************************************************************************";
 }
 
 ##########################################################

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -172,6 +172,15 @@ bundle agent update {
 
 			policy_server::
 				"@@Common@@result_success@@&TRACKINGKEY&@@Update@@None@@$(g.execRun)##$(g.uuid)@#Policy server doesn't need to be updated";
+
+
+                        no_update::
+				"*********************************************************************************
+* rudder-agent could not get an updated configuration from the policy server.   *
+* This can be caused by a network issue, an unavailable server, or if this      *
+* node was deleted from the Rudder root server.                                 *
+* Any existing configuration policy will continue to be applied without change. *
+*********************************************************************************";
 }
 
 


### PR DESCRIPTION
Adding warning message on the initial promises and on the common technique to warn if the node cannot contact the server
The warning is at two different places to have it always dsplayed at the end of the execution for 
- the failsafe execution
- the normal execution
