### PR TITLE
Fixes #3104: Fixed the SuSE generic package installation method

### DIFF
--- a/initial-promises/node-server/common/1.0/cfengine_stdlib.cf
+++ b/initial-promises/node-server/common/1.0/cfengine_stdlib.cf
@@ -1956,7 +1956,7 @@ body package_method generic
 {
 SuSE::
  package_changes => "bulk";
- package_list_command => "/usr/bin/zypper packages";
+ package_list_command => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
  package_patch_list_command => "/usr/bin/zypper patches";
  package_installed_regex => "i.*";
  package_list_name_regex    => "[^|]+\|[^|]+\|\s+([^\s]+).*";

--- a/techniques/system/common/1.0/cfengine_stdlib.st
+++ b/techniques/system/common/1.0/cfengine_stdlib.st
@@ -1956,8 +1956,6 @@ body package_method generic
 {
 SuSE::
  package_changes => "bulk";
- # Removed by MCE: Will be obsoleted by new stdlib version anyway
- # package_list_command => "/usr/bin/zypper packages";
  package_list_command => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
  package_patch_list_command => "/usr/bin/zypper patches";
  package_installed_regex => "i.*";


### PR DESCRIPTION
To be merged in the Rudder 2.4.1 branch
