### PR TITLE
Fixes #3245 - Rename all 'policyInstanceId' remaining into 'directiveId'

### DIFF
--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
@@ -47,12 +47,12 @@ methods:
 
 }
 
-bundle agent check_permissions(policyInstanceId, fileName, user, group, mode, edit_user, edit_group, edit_mode, suid, sgid, recursion) {
+bundle agent check_permissions(directiveId, fileName, user, group, mode, edit_user, edit_group, edit_mode, suid, sgid, recursion) {
 
 
 vars:
 
-	"identifier" string => canonify("$(policyInstanceId)$(fileName)");
+	"identifier" string => canonify("$(directiveId)$(fileName)");
 
 	# See the explication below, before the "classes_defined" class definition
 	classes_defined::
@@ -154,66 +154,66 @@ files:
 reports:
 
 	is_symlink::
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Will not adjust permissions on ${fileName}, because it is a symlink";
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Will not adjust permissions on ${fileName}, because it is a symlink";
 
 	!file_exists::
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#File or directory not found: ${fileName}";
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#File or directory not found: ${fileName}";
 
 	user_absent::
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#The requested user (${user}) was not found on this machine: ${fileName}'s owner can't be set";
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#The requested user (${user}) was not found on this machine: ${fileName}'s owner can't be set";
 
 	group_absent::
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#The requested group (${group}) was not found on this machine: ${fileName}'s group can't be set";
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#The requested group (${group}) was not found on this machine: ${fileName}'s group can't be set";
 
 	edit_recurse::
-		"@@FilesPermissions@@log_info@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Permissions will be applied recursively for ${fileName}";
+		"@@FilesPermissions@@log_info@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Permissions will be applied recursively for ${fileName}";
 
 	file_exists.can_edit_suid_sgid::
 
 	# User
 
-		"@@FilesPermissions@@log_info@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner ${user} already matches current owner for: ${fileName}"
+		"@@FilesPermissions@@log_info@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner ${user} already matches current owner for: ${fileName}"
 			ifvarclass => "$(identifier)_owner_ok.!$(identifier)_owner_repaired";
 
-		"@@FilesPermissions@@log_repaired@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner reset to ${user} for: ${fileName}"
+		"@@FilesPermissions@@log_repaired@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner reset to ${user} for: ${fileName}"
 			ifvarclass => "$(identifier)_owner_repaired";
 
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner ${user} could not be set for: ${fileName}"
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner ${user} could not be set for: ${fileName}"
 			ifvarclass => "$(identifier)_owner_not_repaired";
 
 	# Group
 
-		"@@FilesPermissions@@log_info@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group ${group} already matches current group for: ${fileName}"
+		"@@FilesPermissions@@log_info@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group ${group} already matches current group for: ${fileName}"
 			ifvarclass => "$(identifier)_group_ok.!$(identifier)_group_repaired";
 
-		"@@FilesPermissions@@log_repaired@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group reset to ${group} for: ${fileName}"
+		"@@FilesPermissions@@log_repaired@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group reset to ${group} for: ${fileName}"
 			ifvarclass => "$(identifier)_group_repaired";
 
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group ${group} could not be set for: ${fileName}"
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Group ${group} could not be set for: ${fileName}"
 			ifvarclass => "$(identifier)_group_not_repaired";
 
 	# Mode
 
-		"@@FilesPermissions@@log_info@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode ${extended_modes}${mode} already matches current mode for: ${fileName}"
+		"@@FilesPermissions@@log_info@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode ${extended_modes}${mode} already matches current mode for: ${fileName}"
 			ifvarclass => "$(identifier)_mode_ok.!$(identifier)_mode_repaired";
 
-		"@@FilesPermissions@@log_repaired@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode reset to ${extended_modes}${mode} for: ${fileName}"
+		"@@FilesPermissions@@log_repaired@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode reset to ${extended_modes}${mode} for: ${fileName}"
 			ifvarclass => "$(identifier)_mode_repaired";
 
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode ${extended_modes}${mode} could not be set for: ${fileName}"
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Mode ${extended_modes}${mode} could not be set for: ${fileName}"
 			ifvarclass => "$(identifier)_mode_not_repaired";
 
 	# Final report
 
-		"@@FilesPermissions@@result_success@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group and permissions already correct for ${fileName}"
+		"@@FilesPermissions@@result_success@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group and permissions already correct for ${fileName}"
 			# Success if nothing in error AND nothing repaired
 			ifvarclass => "(!$(identifier)_owner_not_repaired.!$(identifier)_group_not_repaired.!$(identifier)_mode_not_repaired).(!$(identifier)_owner_repaired.!$(identifier)_group_repaired.!$(identifier)_mode_repaired)";
 
-		"@@FilesPermissions@@result_repaired@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group or permissions were fixed for: ${fileName}"
+		"@@FilesPermissions@@result_repaired@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group or permissions were fixed for: ${fileName}"
 			# Repaired if nothing in error AND something repaired
 			ifvarclass => "!$(identifier)_owner_not_repaired.!$(identifier)_group_not_repaired.!$(identifier)_mode_not_repaired.($(identifier)_owner_repaired|$(identifier)_group_repaired|$(identifier)_mode_repaired)";
 
-		"@@FilesPermissions@@result_error@@$(policyInstanceId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group or permissions could not be set for: ${fileName}"
+		"@@FilesPermissions@@result_error@@$(directiveId)@@File permissions@@${fileName}@@$(g.execRun)##$(g.uuid)@#Owner, group or permissions could not be set for: ${fileName}"
 			# Error if something in error
 			ifvarclass => "$(identifier)_owner_not_repaired|$(identifier)_group_not_repaired|$(identifier)_mode_not_repaired";
 

--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/permlist.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/permlist.st
@@ -19,5 +19,5 @@
 # List of files permission
 # Format of the file :
 # policyIsntanceId:file:user:group:mode:edituser:editgroup:editmode:suid:sgid:recursion
-&TRACKINGKEY, FILEPERMISSION_FILENAME, FILEPERMISSION_USER, FILEPERMISSION_GROUP, FILEPERMISSION_MODE, FILEPERMISSION_EDITUSER, FILEPERMISSION_EDITGROUP, FILEPERMISSION_EDITMODE, FILEPERMISSION_SUID, FILEPERMISSION_SGID, FILEPERMISSION_RECURSION:{policyInstanceId, fileName, user, group, perm, edituser, editgroup, editperm, suid, sgid, recursion | &policyInstanceId&:&fileName&:&user&:&group&:&perm&:&edituser&:&editgroup&:&editperm&:&suid&:&sgid&:&recursion&
+&TRACKINGKEY, FILEPERMISSION_FILENAME, FILEPERMISSION_USER, FILEPERMISSION_GROUP, FILEPERMISSION_MODE, FILEPERMISSION_EDITUSER, FILEPERMISSION_EDITGROUP, FILEPERMISSION_EDITMODE, FILEPERMISSION_SUID, FILEPERMISSION_SGID, FILEPERMISSION_RECURSION:{directiveId, fileName, user, group, perm, edituser, editgroup, editperm, suid, sgid, recursion | &directiveId&:&fileName&:&user&:&group&:&perm&:&edituser&:&editgroup&:&editperm&:&suid&:&sgid&:&recursion&
 }&

--- a/techniques/systemSettings/process/processManagement/1.1/processManagement.st
+++ b/techniques/systemSettings/process/processManagement/1.1/processManagement.st
@@ -44,18 +44,18 @@ methods:
 			"$(file[$(procList)][5])");
 
 #reports:
-#		"@@ProcessManagement@@result_error@@$(policyInstanceId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process could not be killed"
+#		"@@ProcessManagement@@result_error@@$(directiveId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process could not be killed"
 #			ifvarclass => canonify("$(blacklist)_kill_failed");
 
-#		"@@ProcessManagement@@result_repaired@@$(policyInstanceId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process has been killed (as requested)"
+#		"@@ProcessManagement@@result_repaired@@$(directiveId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process has been killed (as requested)"
 #			ifvarclass => canonify("$(blacklist)_killed");
 
-#		"@@ProcessManagement@@result_success@@$(policyInstanceId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process is not running (as requested)"
+#		"@@ProcessManagement@@result_success@@$(directiveId)@@Blacklisted process@@$(blacklist)@@$(g.execRun)##$(g.uuid)@#${blacklist}: the process is not running (as requested)"
 #			ifvarclass => canonify("$(blacklist)_ok");
 
 }
 
-bundle agent check_process(policyInstanceId, name, maxInst, minInst, command, args) {
+bundle agent check_process(directiveId, name, maxInst, minInst, command, args) {
 
 classes:
 
@@ -90,22 +90,22 @@ reports:
   		
   	(linux|!linux)::
 
-  		"@@ProcessManagement@@result_error@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process count could't be checked"
+  		"@@ProcessManagement@@result_error@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process count could't be checked"
 			ifvarclass => canonify("$(name)_error");
 
-		"@@ProcessManagement@@log_info@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process instance count is out of the permitted range"
+		"@@ProcessManagement@@log_info@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process instance count is out of the permitted range"
 			ifvarclass => canonify("$(name)_anomaly");
 
-		"@@ProcessManagement@@log_info@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process will be restarted"
+		"@@ProcessManagement@@log_info@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process will be restarted"
 			ifvarclass => canonify("$(name)_restart");
 
-		"@@ProcessManagement@@result_success@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process was in range ($(minInst)-$(maxInst))"
+		"@@ProcessManagement@@result_success@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process was in range ($(minInst)-$(maxInst))"
 			ifvarclass => canonify("$(name)_ok");
 
-		"@@ProcessManagement@@result_repaired@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process has been restarted"
+		"@@ProcessManagement@@result_repaired@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process has been restarted"
 			ifvarclass => canonify("$(name)_restart_ok");
 
-		"@@ProcessManagement@@result_error@@$(policyInstanceId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process could not be restarted"
+		"@@ProcessManagement@@result_error@@$(directiveId)@@Process@@$(name)@@$(g.execRun)##$(g.uuid)@#${name}: the process could not be restarted"
 			ifvarclass => canonify("$(name)_restart_error");
 
 

--- a/techniques/systemSettings/process/processManagement/1.1/proclist.st
+++ b/techniques/systemSettings/process/processManagement/1.1/proclist.st
@@ -19,5 +19,5 @@
 # List of the process parameters to enforce
 # Format of the file :
 # policyIsntanceId, name:maximum_instances:minimum_instances
-&TRACKINGKEY, PROCESS_NAME, PROCESS_MIN_INSTANCES, PROCESS_MAX_INSTANCES, PROCESS_COMMAND, PROCESS_MAX_ARGS:{policyInstanceId, name, maxInst, minInst, command, args | &policyInstanceId&,&name&,&maxInst&,&minInst&,&command&,&args&
+&TRACKINGKEY, PROCESS_NAME, PROCESS_MIN_INSTANCES, PROCESS_MAX_INSTANCES, PROCESS_COMMAND, PROCESS_MAX_ARGS:{directiveId, name, maxInst, minInst, command, args | &directiveId&,&name&,&maxInst&,&minInst&,&command&,&args&
 }&


### PR DESCRIPTION
Fixes #3245 - Rename all 'policyInstanceId' remaining into 'directiveId'
