### PR TITLE
Fixes #3257: Fixes the permlist loading limit which is too restrictive f...

### DIFF
--- a/policies/fileConfiguration/fileSecurity/filesPermissions/1.0/filesPermissions.st
+++ b/policies/fileConfiguration/fileSecurity/filesPermissions/1.0/filesPermissions.st
@@ -27,7 +27,7 @@
 bundle agent files_permissions {
 vars:
 
-"dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,120400);
+"dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,102400);
 
 "filePerms" slist => getindices("file");
 

--- a/policies/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
+++ b/policies/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
@@ -27,7 +27,7 @@
 bundle agent files_permissions {
 vars:
 
-"dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,120400);
+"dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,102400);
 
 "filePerms" slist => getindices("file");
 


### PR DESCRIPTION
...or large permlists

To be merged in the 2.3 branch.

Bug: https://www.rudder-project.org/redmine/issues/3257
