### PR TITLE
Fixes #3313 - Rework indentations in Techniques 'RUG / YaST package manager configuration (ZMD)', 'Zypper package manager configuration','Package repositories management (Rug)' and 'Package repositories management (RPM)'

### DIFF
--- a/techniques/applications/packageRepositoriesManagementRPM/1.0/metadata.xml
+++ b/techniques/applications/packageRepositoriesManagementRPM/1.0/metadata.xml
@@ -1,0 +1,99 @@
+<!--
+Copyright 2013 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<TECHNIQUE name="Package repositories management (RPM)">
+  <DESCRIPTION>This technique configure the repositories of the package manager in RPM based systems.</DESCRIPTION>
+
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+
+  <COMPATIBLE>
+    <OS version=">= 10 SP1 (Agama Lizard)">SuSE LES / DES / OpenSuSE</OS>
+    <AGENT version=">= 3.2.0">cfengine-community</AGENT>
+  </COMPATIBLE>
+
+  <BUNDLES>
+    <NAME>check_pkg_manager_repositories</NAME>
+  </BUNDLES>
+
+  <TMLS>
+    <TML name="packageRepositoriesManagementRPM"/>
+  </TMLS>
+  
+  <TRACKINGVARIABLE>
+    <SAMESIZEAS>PKG_MGR_URL</SAMESIZEAS>
+  </TRACKINGVARIABLE>
+    
+  <SECTIONS>
+    <!-- Repository settings Section , index 20 -->
+    <SECTION name="Repository settings">
+      <SECTION name="Repository" multivalued="true" component="true" componentKey="PKG_MGR_NAME">
+        <INPUT>
+          <NAME>PKG_MGR_NAME</NAME>
+          <DESCRIPTION>Repository name</DESCRIPTION>
+	  <CONSTRAINT>
+	    <MAYBEEMPTY>false</MAYBEEMPTY>
+	  </CONSTRAINT>
+	</INPUT>
+        <INPUT>
+          <NAME>PKG_MGR_URL</NAME>
+          <DESCRIPTION>Repository URL</DESCRIPTION>
+	  <CONSTRAINT>
+	    <MAYBEEMPTY>false</MAYBEEMPTY>
+	  </CONSTRAINT>
+	</INPUT>
+        <INPUT>
+          <NAME>PKG_MGR_TYPE</NAME>
+          <DESCRIPTION>Repository type</DESCRIPTION>
+          <LONGDESCRIPTION>You should not modify this entry, do it only if you know what you are doing</LONGDESCRIPTION>
+          <ITEM>
+            <VALUE>rpm-md</VALUE>
+            <LABEL>RPM MD</LABEL>
+          </ITEM>
+          <ITEM>
+            <VALUE>yast2</VALUE>
+            <LABEL>Yast 2</LABEL>
+          </ITEM>
+	  <CONSTRAINT>
+	    <DEFAULT>yast2</DEFAULT>
+	  </CONSTRAINT>
+	</INPUT>
+        <SELECT1>
+          <NAME>PKG_MGR_ENABLED</NAME>
+          <DESCRIPTION>Enabled</DESCRIPTION>
+          <ITEM>
+            <VALUE>0</VALUE>
+            <LABEL>No</LABEL>
+          </ITEM>
+          <ITEM>
+            <VALUE>1</VALUE>
+            <LABEL>Yes</LABEL>
+          </ITEM>
+	    <CONSTRAINT>
+	      <DEFAULT>1</DEFAULT>
+	    </CONSTRAINT>
+        </SELECT1>
+      </SECTION>
+      <INPUT>
+        <NAME>PKG_MGR_DISABLEREPOSITORIES</NAME>
+        <DESCRIPTION>Delete all other repositories than these (potentially dangerous)</DESCRIPTION>
+        <CONSTRAINT>
+          <TYPE>boolean</TYPE>
+          <DEFAULT>false</DEFAULT>
+        </CONSTRAINT>
+      </INPUT>
+    </SECTION>
+  </SECTIONS>
+
+</TECHNIQUE>

--- a/techniques/applications/packageRepositoriesManagementRPM/1.0/metadata.xml
+++ b/techniques/applications/packageRepositoriesManagementRPM/1.0/metadata.xml
@@ -42,16 +42,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <INPUT>
           <NAME>PKG_MGR_NAME</NAME>
           <DESCRIPTION>Repository name</DESCRIPTION>
-	  <CONSTRAINT>
-	    <MAYBEEMPTY>false</MAYBEEMPTY>
-	  </CONSTRAINT>
 	</INPUT>
         <INPUT>
           <NAME>PKG_MGR_URL</NAME>
           <DESCRIPTION>Repository URL</DESCRIPTION>
-	  <CONSTRAINT>
-	    <MAYBEEMPTY>false</MAYBEEMPTY>
-	  </CONSTRAINT>
 	</INPUT>
         <INPUT>
           <NAME>PKG_MGR_TYPE</NAME>

--- a/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
+++ b/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
@@ -66,25 +66,21 @@ bundle agent check_pkg_manager_repositories {
 		# Zypper repositories desactivation
 
                 pkg_mgr_disablerepositories.!repos_disabled_ok.!repos_disabled_fail::
-                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were already disabled";
+                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were already disabled";
 
                 pkg_mgr_disablerepositories.repos_disabled_ok::
-                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were disabled";
+                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were disabled";
 
                 pkg_mgr_disablerepositories.repos_disabled_fail::
-                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Could not disable the other repositories!";
+                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Could not disable the other repositories!";
 
                 !pkg_mgr_disablerepositories::
-                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#The repository desactivation has not been requested. Skipping...";
+                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#The repository desactivation has not been requested. Skipping...";
 
 		# Ignore non-SuSE OSes
 
 		!SuSE::
-			"@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@zypperPackageManagerSettings@@None@@$(g.execRun)##$(g.uuid)@#ZYPPER cannot be configured on non SuSE OSes";
-
-		!pkg_mgr_repositories_edit::
-
-			"@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The source $(pkg_mgr_name[$(pkg_mgr_index)]) will NOT be added as the repository addition parameter is off in the Policy Instance. Skipping...";
+			"@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZYPPER cannot be configured on none SuSE OSes";
 
 		SuSE::
 

--- a/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
+++ b/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
@@ -1,0 +1,114 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+######################################################
+# Configures the Zypper Package Manager Repositories #
+######################################################
+
+bundle agent check_pkg_manager_repositories {
+
+	vars:
+
+		&PKG_MGR_NAME:{pkg_mgr_name |"pkg_mgr_name[&i&]" string => "&pkg_mgr_name&";
+}&
+		&PKG_MGR_URL:{pkg_mgr_url |"pkg_mgr_url[&i&]" string => "&pkg_mgr_url&";
+}&
+		&PKG_MGR_TYPE:{pkg_mgr_type |"pkg_mgr_type[&i&]" string => "&pkg_mgr_type&";
+}&
+		&PKG_MGR_ENABLED:{pkg_mgr_enabled |"pkg_mgr_enabled[&i&]" string => "&pkg_mgr_enabled&";
+}&
+
+                # List of all the files to permit on the vhost directory
+                "pkg_mgr_files" slist => { &PKG_MGR_NAME: { "rudder-&it&.repo" };separator=", "&};
+
+		"pkg_mgr_index" slist => getindices("pkg_mgr_name");
+
+	classes:
+
+		# Disable repositories ?
+		"pkg_mgr_disablerepositories" not => strcmp("&PKG_MGR_DISABLEREPOSITORIES&","false");
+
+	files:
+
+		SuSE::
+                        "/etc/zypp/repos.d/rudder-$(pkg_mgr_name[$(pkg_mgr_index)]).repo"
+                                create => "true",
+                                perms => m("644"),
+                                edit_line => set_zypper_repos("$(pkg_mgr_name[$(pkg_mgr_index)])", "$(pkg_mgr_url[$(pkg_mgr_index)])", "$(pkg_mgr_enabled[$(pkg_mgr_index)])", "$(pkg_mgr_type[$(pkg_mgr_index)])", "$(g.rudder_dependencies)/zypper-repo.tpl"),
+                                edit_defaults => empty_backup,
+                                classes =>  kept_if_else("pkg_mgr_$(pkg_mgr_index)_kept", "pkg_mgr_$(pkg_mgr_index)_validated", "pkg_mgr_$(pkg_mgr_index)_failed");
+
+		SuSE.pkg_mgr_disablerepositories::
+
+                        "/etc/zypp/repos.d/.*"
+                                delete => tidy,
+                                file_select => ex_list("@(pkg_mgr_files)"),
+                                depth_search => recurse("inf"),
+                                classes => kept_if_else("repos_disabled_kept", "repos_disabled_ok", "repos_disabled_fail"),
+				comment => "Delete the unwanted repos as requested";
+
+	reports:
+		# Zypper repositories desactivation
+
+                pkg_mgr_disablerepositories.!repos_disabled_ok.!repos_disabled_fail::
+                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were already disabled";
+
+                pkg_mgr_disablerepositories.repos_disabled_ok::
+                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were disabled";
+
+                pkg_mgr_disablerepositories.repos_disabled_fail::
+                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Could not disable the other repositories!";
+
+                !pkg_mgr_disablerepositories::
+                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@General settings@@None@@$(g.execRun)##$(g.uuid)@#The repository desactivation has not been requested. Skipping...";
+
+		# Ignore non-SuSE OSes
+
+		!SuSE::
+			"@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@zypperPackageManagerSettings@@None@@$(g.execRun)##$(g.uuid)@#ZYPPER cannot be configured on non SuSE OSes";
+
+		!pkg_mgr_repositories_edit::
+
+			"@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The source $(pkg_mgr_name[$(pkg_mgr_index)]) will NOT be added as the repository addition parameter is off in the Policy Instance. Skipping...";
+
+		SuSE::
+
+                # Repositories
+
+                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was already here. Skipping..."
+                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_kept.!pkg_mgr_$(pkg_mgr_index)_validated";
+
+                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) has been successfully added"
+                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_validated";
+
+                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was NOT added!"
+                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_error";
+
+
+}
+
+bundle edit_line set_zypper_repos(zypper_name, zypper_url, zypper_enabled, zypper_type, template)
+{
+
+insert_lines:
+
+                "$(template)"
+                        insert_type => "file",
+                        expand_scalars => "true";
+
+}

--- a/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
+++ b/techniques/applications/packageRepositoriesManagementRPM/1.0/packageRepositoriesManagementRPM.st
@@ -20,91 +20,89 @@
 # Configures the Zypper Package Manager Repositories #
 ######################################################
 
-bundle agent check_pkg_manager_repositories {
+bundle agent check_pkg_manager_repositories
+{
+  vars:
 
-	vars:
-
-		&PKG_MGR_NAME:{pkg_mgr_name |"pkg_mgr_name[&i&]" string => "&pkg_mgr_name&";
+      &PKG_MGR_NAME:{pkg_mgr_name |"pkg_mgr_name[&i&]" string => "&pkg_mgr_name&";
 }&
-		&PKG_MGR_URL:{pkg_mgr_url |"pkg_mgr_url[&i&]" string => "&pkg_mgr_url&";
+      &PKG_MGR_URL:{pkg_mgr_url |"pkg_mgr_url[&i&]" string => "&pkg_mgr_url&";
 }&
-		&PKG_MGR_TYPE:{pkg_mgr_type |"pkg_mgr_type[&i&]" string => "&pkg_mgr_type&";
+      &PKG_MGR_TYPE:{pkg_mgr_type |"pkg_mgr_type[&i&]" string => "&pkg_mgr_type&";
 }&
-		&PKG_MGR_ENABLED:{pkg_mgr_enabled |"pkg_mgr_enabled[&i&]" string => "&pkg_mgr_enabled&";
+      &PKG_MGR_ENABLED:{pkg_mgr_enabled |"pkg_mgr_enabled[&i&]" string => "&pkg_mgr_enabled&";
 }&
 
-                # List of all the files to permit on the vhost directory
-                "pkg_mgr_files" slist => { &PKG_MGR_NAME: { "rudder-&it&.repo" };separator=", "&};
+      # List of all the files to permit on the vhost directory
+      "pkg_mgr_files" slist => { &PKG_MGR_NAME: { "rudder-&it&.repo" };separator=", "&};
 
-		"pkg_mgr_index" slist => getindices("pkg_mgr_name");
+      "pkg_mgr_index" slist => getindices("pkg_mgr_name");
 
-	classes:
+  classes:
 
-		# Disable repositories ?
-		"pkg_mgr_disablerepositories" not => strcmp("&PKG_MGR_DISABLEREPOSITORIES&","false");
+      # Disable repositories ?
+      "pkg_mgr_disablerepositories" not => strcmp("&PKG_MGR_DISABLEREPOSITORIES&","false");
 
-	files:
+  files:
 
-		SuSE::
-                        "/etc/zypp/repos.d/rudder-$(pkg_mgr_name[$(pkg_mgr_index)]).repo"
-                                create => "true",
-                                perms => m("644"),
-                                edit_line => set_zypper_repos("$(pkg_mgr_name[$(pkg_mgr_index)])", "$(pkg_mgr_url[$(pkg_mgr_index)])", "$(pkg_mgr_enabled[$(pkg_mgr_index)])", "$(pkg_mgr_type[$(pkg_mgr_index)])", "$(g.rudder_dependencies)/zypper-repo.tpl"),
-                                edit_defaults => empty_backup,
-                                classes =>  kept_if_else("pkg_mgr_$(pkg_mgr_index)_kept", "pkg_mgr_$(pkg_mgr_index)_validated", "pkg_mgr_$(pkg_mgr_index)_failed");
+    SuSE::
+      "/etc/zypp/repos.d/rudder-$(pkg_mgr_name[$(pkg_mgr_index)]).repo"
+        create        => "true",
+        perms         => m("644"),
+        edit_line     => set_zypper_repos(
+                                          "$(pkg_mgr_name[$(pkg_mgr_index)])",
+                                          "$(pkg_mgr_url[$(pkg_mgr_index)])",
+                                          "$(pkg_mgr_enabled[$(pkg_mgr_index)])",
+                                          "$(pkg_mgr_type[$(pkg_mgr_index)])",
+                                          "$(g.rudder_dependencies)/zypper-repo.tpl"
+                                          ),
+        edit_defaults => empty_backup,
+        classes       =>  kept_if_else("pkg_mgr_$(pkg_mgr_index)_kept", "pkg_mgr_$(pkg_mgr_index)_validated", "pkg_mgr_$(pkg_mgr_index)_failed");
 
-		SuSE.pkg_mgr_disablerepositories::
+    SuSE.pkg_mgr_disablerepositories::
+      "/etc/zypp/repos.d/.*"
+        delete       => tidy,
+        file_select  => ex_list("@(pkg_mgr_files)"),
+        depth_search => recurse("inf"),
+        classes      => kept_if_else("repos_disabled_kept", "repos_disabled_ok", "repos_disabled_fail"),
+        comment      => "Delete the unwanted repos as requested";
 
-                        "/etc/zypp/repos.d/.*"
-                                delete => tidy,
-                                file_select => ex_list("@(pkg_mgr_files)"),
-                                depth_search => recurse("inf"),
-                                classes => kept_if_else("repos_disabled_kept", "repos_disabled_ok", "repos_disabled_fail"),
-				comment => "Delete the unwanted repos as requested";
+  reports:
+      # Zypper repositories desactivation
 
-	reports:
-		# Zypper repositories desactivation
+    pkg_mgr_disablerepositories.!repos_disabled_ok.!repos_disabled_fail::
+      "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were already disabled";
 
-                pkg_mgr_disablerepositories.!repos_disabled_ok.!repos_disabled_fail::
-                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were already disabled";
+    pkg_mgr_disablerepositories.repos_disabled_ok::
+      "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were disabled";
 
-                pkg_mgr_disablerepositories.repos_disabled_ok::
-                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Every repository other than the defined ones were disabled";
+    pkg_mgr_disablerepositories.repos_disabled_fail::
+      "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Could not disable the other repositories!";
 
-                pkg_mgr_disablerepositories.repos_disabled_fail::
-                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#Could not disable the other repositories!";
+    !pkg_mgr_disablerepositories::
+      "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#The repository desactivation has not been requested. Skipping...";
 
-                !pkg_mgr_disablerepositories::
-                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#The repository desactivation has not been requested. Skipping...";
+    # Ignore non-SuSE OSes
+    !SuSE::
+      "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZYPPER cannot be configured on none SuSE OSes";
 
-		# Ignore non-SuSE OSes
+    SuSE::
+    # Repositories
+      "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was already here. Skipping..."
+        ifvarclass => "pkg_mgr_$(pkg_mgr_index)_kept.!pkg_mgr_$(pkg_mgr_index)_validated";
 
-		!SuSE::
-			"@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZYPPER cannot be configured on none SuSE OSes";
+      "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) has been successfully added"
+        ifvarclass => "pkg_mgr_$(pkg_mgr_index)_validated";
 
-		SuSE::
-
-                # Repositories
-
-                        "@@Package repositories management RPM@@result_success@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was already here. Skipping..."
-                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_kept.!pkg_mgr_$(pkg_mgr_index)_validated";
-
-                        "@@Package repositories management RPM@@result_repaired@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) has been successfully added"
-                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_validated";
-
-                        "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was NOT added!"
-                                ifvarclass => "pkg_mgr_$(pkg_mgr_index)_error";
-
-
+      "@@Package repositories management RPM@@result_error@@&TRACKINGKEY&@@Repository@@$(pkg_mgr_name[$(pkg_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The Zypper source $(pkg_mgr_name[$(pkg_mgr_index)]) was NOT added!"
+        ifvarclass => "pkg_mgr_$(pkg_mgr_index)_error";
 }
 
 bundle edit_line set_zypper_repos(zypper_name, zypper_url, zypper_enabled, zypper_type, template)
 {
+  insert_lines:
 
-insert_lines:
-
-                "$(template)"
-                        insert_type => "file",
-                        expand_scalars => "true";
-
+      "$(template)"
+        insert_type    => "file",
+        expand_scalars => "true";
 }

--- a/techniques/applications/packageRepositoriesManagementRug/1.0/metadata.xml
+++ b/techniques/applications/packageRepositoriesManagementRug/1.0/metadata.xml
@@ -1,0 +1,56 @@
+<!--
+Copyright 2011 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<TECHNIQUE name="Package repositories management (Rug)">
+  <DESCRIPTION>This technique configure the repositories of the package manager in RPM based systems (Rug especially).</DESCRIPTION>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <COMPATIBLE>
+    <OS version=">= 10 SP1 (Agama Lizard)">SuSE LES / DES / OpenSuSE</OS>
+    <AGENT version=">= 3.2.0">cfengine-community</AGENT>
+  </COMPATIBLE>
+
+  <BUNDLES>
+    <NAME>check_rug_mgr_repositories</NAME>
+  </BUNDLES>
+
+  <TMLS>
+    <TML name="packageRepositoriesManagementRug"/>
+  </TMLS>
+  
+  <TRACKINGVARIABLE>
+    <SAMESIZEAS>RUG_MGR_NAME</SAMESIZEAS>
+  </TRACKINGVARIABLE>
+    
+  <SECTIONS>
+    <!-- Repository settings Section -->
+      <SECTION name="Repository" multivalued="true" component="true" componentKey="RUG_MGR_NAME">
+        <INPUT>
+          <NAME>RUG_MGR_NAME</NAME>
+          <DESCRIPTION>Repository local name</DESCRIPTION>
+          <CONSTRAINT>
+            <MAYBEEMPTY>false</MAYBEEMPTY>
+          </CONSTRAINT>
+        </INPUT>
+	<INPUT>
+          <NAME>RUG_MGR_URL</NAME>
+          <DESCRIPTION>Repository URL</DESCRIPTION>
+          <CONSTRAINT>
+            <MAYBEEMPTY>false</MAYBEEMPTY>
+          </CONSTRAINT>
+	</INPUT>
+      </SECTION>
+  </SECTIONS>
+
+</TECHNIQUE>

--- a/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
+++ b/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
@@ -20,69 +20,64 @@
 # Configures the RUG/YaST Package Managers using ZMD #
 ######################################################
 
-bundle agent check_rug_mgr_repositories {
-
-	vars:
-		class_ok::
-		&TRACKINGKEY:{directiveId |"rug_mgr_conf[uuid][&i&]" string => "&directiveId&";
+bundle agent check_rug_mgr_repositories
+{
+  vars:
+    class_ok::
+      &TRACKINGKEY:{directiveId |"rug_mgr_conf[uuid][&i&]" string => "&directiveId&";
 }&
-		&ZMD_URL:{rug_mgr_url |"rug_mgr_url[&i&]" string => "&rug_mgr_url&";
+      &ZMD_URL:{rug_mgr_url |"rug_mgr_url[&i&]" string => "&rug_mgr_url&";
 }&
-		&ZMD_NAME:{rug_mgr_name |"rug_mgr_name[&i&]" string => "&rug_mgr_name&";
+      &ZMD_NAME:{rug_mgr_name |"rug_mgr_name[&i&]" string => "&rug_mgr_name&";
 }&
-		"rug_mgr_index" slist => getindices("rug_mgr_url");
+      "rug_mgr_index" slist => getindices("rug_mgr_url");
 
-	classes:
+  classes:
 
-		# Is the checkzmd script present ?
-		"checkzmd_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
+      # Is the checkzmd script present ?
+      "checkzmd_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
 
-		"class_ok" expression => strcmp("true", "true");
+      "class_ok"         expression => strcmp("true", "true");
 
-		"showtime" expression => isvariable("rug_mgr_sections");
+      "showtime"         expression => isvariable("rug_mgr_sections");
 
-	commands:
+  commands:
 
-		showtime.SuSE.checkzmd_present::
+    showtime.SuSE.checkzmd_present::
+      "${g.rudder_dependencies}/checkzmd.pl \"$(rug_mgr_name[$(rug_mgr_index)])\" \"$(rug_mgr_url[$(rug_mgr_index)])\" $(rug_mgr_index)"
+        contain => in_shell,
+        module => "true",
+        comment => "Analyzing ZMD's output";
 
-			"${g.rudder_dependencies}/checkzmd.pl \"$(rug_mgr_name[$(rug_mgr_index)])\" \"$(rug_mgr_url[$(rug_mgr_index)])\" $(rug_mgr_index)"
-				contain => in_shell,
-				module => "true",
-				comment => "Analyzing ZMD's output";
+    showtime.SuSE::
+      "/usr/bin/rug"
+        args => "sa --type=zypp \"$(rug_mgr_url[$(rug_mgr_index)])\" \"$(rug_mgr_name[$(rug_mgr_index)])\"",
+        ifvarclass => "index_$(rug_mgr_index)_not_matched",
+        classes => kept_if_else("source_$(rug_mgr_index)_kept", "source_$(rug_mgr_index)_added", "source_$(rug_mgr_index)_failed"),
+        comment => "Add the $(rug_mgr_index) as a new source";
 
-		showtime.SuSE::
+      "/usr/bin/rug"
+        args => "subscribe \"$(rug_mgr_name[$(rug_mgr_index)])\"",
+        ifvarclass => "source_$(rug_mgr_index)_added",
+        classes => kept_if_else("source_$(rug_mgr_index)_subkept", "source_$(rug_mgr_index)_subscribed", "source_$(rug_mgr_index)_subfailed"),
+        comment => "Subscribe $(rug_mgr_index) as a new source";
+    
+  reports:
+    # Ignore non-SuSE OSes
+    !SuSE::
+      "@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
 
-			"/usr/bin/rug"
-				args => "sa --type=zypp \"$(rug_mgr_url[$(rug_mgr_index)])\" \"$(rug_mgr_name[$(rug_mgr_index)])\"",
-				ifvarclass => "index_$(rug_mgr_index)_not_matched",
-				classes => kept_if_else("source_$(rug_mgr_index)_kept", "source_$(rug_mgr_index)_added", "source_$(rug_mgr_index)_failed"),
-				comment => "Add the $(rug_mgr_index) as a new source";
+    SuSE::
+      # Repositories
+      "@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was already here. Skipping..."
+        ifvarclass => "index_$(rug_mgr_index)_matched.!source_$(rug_mgr_index)_subscribed";
 
-			"/usr/bin/rug"
-				args => "subscribe \"$(rug_mgr_name[$(rug_mgr_index)])\"",
-				ifvarclass => "source_$(rug_mgr_index)_added",
-				classes => kept_if_else("source_$(rug_mgr_index)_subkept", "source_$(rug_mgr_index)_subscribed", "source_$(rug_mgr_index)_subfailed"),
-				comment => "Subscribe $(rug_mgr_index) as a new source";
-				
-	reports:
-		# Ignore non-SuSE OSes
+      "@@Package repositories management Rug@@result_repaired@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) has been successfully added"
+        ifvarclass => "index_$(rug_mgr_index)_not_matched.source_$(rug_mgr_index)_subscribed";
 
-		!SuSE::
-			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+      "@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not register the source !"
+        ifvarclass => "source_$(rug_mgr_index)_failed";
 
-		SuSE::
-
-			# Repositories
-
-			"@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was already here. Skipping..."
-				ifvarclass => "index_$(rug_mgr_index)_matched.!source_$(rug_mgr_index)_subscribed";
-
-			"@@Package repositories management Rug@@result_repaired@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) has been successfully added"
-				ifvarclass => "index_$(rug_mgr_index)_not_matched.source_$(rug_mgr_index)_subscribed";
-
-			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not register the source !"
-				ifvarclass => "source_$(rug_mgr_index)_failed";
-
-			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not subscribe to the source !"
-				ifvarclass => "source_$(rug_mgr_index)_subfailed";
+      "@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not subscribe to the source !"
+        ifvarclass => "source_$(rug_mgr_index)_subfailed";
 }

--- a/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
+++ b/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
@@ -1,0 +1,91 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+######################################################
+# Configures the RUG/YaST Package Managers using ZMD #
+######################################################
+
+bundle agent check_rug_mgr_repositories {
+
+	vars:
+		class_ok::
+		&TRACKINGKEY:{directiveId |"rug_mgr_conf[uuid][&i&]" string => "&directiveId&";
+}&
+		&ZMD_URL:{rug_mgr_url |"rug_mgr_url[&i&]" string => "&rug_mgr_url&";
+}&
+		&ZMD_NAME:{rug_mgr_name |"rug_mgr_name[&i&]" string => "&rug_mgr_name&";
+}&
+		"rug_mgr_index" slist => getindices("rug_mgr_url");
+
+	classes:
+
+		# Is the checkzmd script present ?
+		"checkrug_mgr_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
+
+		"class_ok" expression => strcmp("true", "true");
+
+		"showtime" expression => isvariable("rug_mgr_sections");
+
+	commands:
+
+		showtime.SuSE.checkzmd_present::
+
+			"${g.rudder_dependencies}/checkzmd.pl \"$(rug_mgr_name[$(rug_mgr_index)])\" \"$(rug_mgr_url[$(rug_mgr_index)])\" $(rug_mgr_index)"
+				contain => in_shell,
+				module => "true",
+				comment => "Analyzing ZMD's output";
+
+		showtime.SuSE.rug_mgr_repositories_edit::
+
+			"/usr/bin/rug"
+				args => "sa --type=zypp \"$(rug_mgr_url[$(rug_mgr_index)])\" \"$(rug_mgr_name[$(rug_mgr_index)])\"",
+				ifvarclass => "index_$(rug_mgr_index)_not_matched",
+				classes => kept_if_else("source_$(rug_mgr_index)_kept", "source_$(rug_mgr_index)_added", "source_$(rug_mgr_index)_failed"),
+				comment => "Add the $(rug_mgr_index) as a new source";
+
+			"/usr/bin/rug"
+				args => "subscribe \"$(rug_mgr_name[$(rug_mgr_index)])\"",
+				ifvarclass => "source_$(rug_mgr_index)_added",
+				classes => kept_if_else("source_$(rug_mgr_index)_subkept", "source_$(rug_mgr_index)_subscribed", "source_$(rug_mgr_index)_subfailed"),
+				comment => "Subscribe $(rug_mgr_index) as a new source";
+				
+	reports:
+		# Ignore non-SuSE OSes
+
+		!SuSE::
+			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+
+		SuSE::
+
+			# Repositories
+
+			"@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) is not here but no edition required. Skipping..."
+				ifvarclass => "index_$(rug_mgr_index)_not_matched.!rug_mgr_repositories_edit";
+
+			"@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was already here. Skipping..."
+				ifvarclass => "index_$(rug_mgr_index)_matched.!source_$(rug_mgr_index)_subscribed";
+
+			"@@Package repositories management Rug@@result_repaired@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) has been successfully added"
+				ifvarclass => "index_$(rug_mgr_index)_not_matched.source_$(rug_mgr_index)_subscribed";
+
+			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not register the source !"
+				ifvarclass => "source_$(rug_mgr_index)_failed";
+
+			"@@Package repositories management Rug@@result_error@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was NOT added : Could not subscribe to the source !"
+				ifvarclass => "source_$(rug_mgr_index)_subfailed";
+}

--- a/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
+++ b/techniques/applications/packageRepositoriesManagementRug/1.0/packageRepositoriesManagementRug.st
@@ -35,7 +35,7 @@ bundle agent check_rug_mgr_repositories {
 	classes:
 
 		# Is the checkzmd script present ?
-		"checkrug_mgr_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
+		"checkzmd_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
 
 		"class_ok" expression => strcmp("true", "true");
 
@@ -50,7 +50,7 @@ bundle agent check_rug_mgr_repositories {
 				module => "true",
 				comment => "Analyzing ZMD's output";
 
-		showtime.SuSE.rug_mgr_repositories_edit::
+		showtime.SuSE::
 
 			"/usr/bin/rug"
 				args => "sa --type=zypp \"$(rug_mgr_url[$(rug_mgr_index)])\" \"$(rug_mgr_name[$(rug_mgr_index)])\"",
@@ -73,9 +73,6 @@ bundle agent check_rug_mgr_repositories {
 		SuSE::
 
 			# Repositories
-
-			"@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) is not here but no edition required. Skipping..."
-				ifvarclass => "index_$(rug_mgr_index)_not_matched.!rug_mgr_repositories_edit";
 
 			"@@Package repositories management Rug@@result_success@@&TRACKINGKEY&@@Repository@@$(rug_mgr_url[$(rug_mgr_index)])@@$(g.execRun)##$(g.uuid)@#The ZMD source $(rug_mgr_name[$(rug_mgr_index)]) was already here. Skipping..."
 				ifvarclass => "index_$(rug_mgr_index)_matched.!source_$(rug_mgr_index)_subscribed";

--- a/techniques/applications/zmdPackageManagerSettings/1.0/zmdPackageManagerSettings.st
+++ b/techniques/applications/zmdPackageManagerSettings/1.0/zmdPackageManagerSettings.st
@@ -22,80 +22,72 @@
 
 bundle agent check_zmd_settings
 {
-
   vars:
 
     proxy_edit::
-
-      "zmdconf[Network][proxy-url]" string => "&ZMD_PROXY_URL&";
+      "zmdconf[Network][proxy-url]"        string => "&ZMD_PROXY_URL&";
 
     proxy_edit_user::
-
-      "zmdconf[Network][proxy-username]" string => "&ZMD_PROXY_USER&";
+      "zmdconf[Network][proxy-username]"   string => "&ZMD_PROXY_USER&";
 
     proxy_edit_password::
-
-      "zmdconf[Network][proxy-password]" string => "&ZMD_PROXY_PASSWORD&";
+      "zmdconf[Network][proxy-password]"   string => "&ZMD_PROXY_PASSWORD&";
 
     class_ok::
-
-    &ZMD_URL:{zmd_url |"zmd_url[&i&]" string => "&zmd_url&";
+      &ZMD_URL:{zmd_url |"zmd_url[&i&]"    string => "&zmd_url&";
 }&
-    &ZMD_NAME:{zmd_name |"zmd_name[&i&]" string => "&zmd_name&";
+      &ZMD_NAME:{zmd_name |"zmd_name[&i&]" string => "&zmd_name&";
 }&
-      "zmd_index" slist => getindices("zmd_url");
+      "zmd_index"                          slist  => getindices("zmd_url");
 
 &if(ZMD_SET_REFRESH_INTERVAL)&
       "zmdconf[Server][refresh-interval]" string => "&ZMD_REFRESH_INTERVAL&";
 &endif&
       "zmdconf[Advanced][security-level]" string => "&ZMD_SOURCEPOLICY&";
 
-      "zmdconf[Server][remote-enabled]" string => "&ZMD_REMOTE_ENABLED&";
+      "zmdconf[Server][remote-enabled]"   string => "&ZMD_REMOTE_ENABLED&";
 
-      "zmdconf[Debug][syslog-level]" string => "&ZMD_SYSLOG_LEVEL&";
+      "zmdconf[Debug][syslog-level]"      string => "&ZMD_SYSLOG_LEVEL&";
 
-      "zmd_sections" slist => getindices("zmdconf");
+      "zmd_sections"                      slist  => getindices("zmdconf");
 
   classes:
 
     # Repositories edition ?
-      "zmd_repositories_edit" not => strcmp("&ZMD_ADDREPOSITORIES&","false");
+      "zmd_repositories_edit"   not        => strcmp("&ZMD_ADDREPOSITORIES&","false");
 
     # Disable repositories ?
-      "zmd_disablerepositories" not => strcmp("&ZMD_DISABLEREPOSITORIES&","false");
+      "zmd_disablerepositories" not        => strcmp("&ZMD_DISABLEREPOSITORIES&","false");
 
     # Is the checkzmd script present ?
-      "checkzmd_present" expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
+      "checkzmd_present"        expression => fileexists("${g.rudder_dependencies}/checkzmd.pl");
 
     # Do we want to set the proxy ?
-      "proxy_edit" not => strcmp("&ZMD_PROXY_URL&", "");
+      "proxy_edit"              not        => strcmp("&ZMD_PROXY_URL&", "");
 
     # Do we want to set the proxy username ?
-      "proxy_edit_user" not => strcmp("&ZMD_PROXY_USER&", "");
+      "proxy_edit_user"         not        => strcmp("&ZMD_PROXY_USER&", "");
 
     # Do we want to set the proxy username ?
-      "proxy_edit_password" not => strcmp("&ZMD_PROXY_PASSWORD&", "");
+      "proxy_edit_password"     not        => strcmp("&ZMD_PROXY_PASSWORD&", "");
 
-      "class_ok" expression => strcmp("true", "true");
+      "class_ok"                expression => strcmp("true", "true");
 
-      "showtime" expression => isvariable("zmd_sections");
+      "showtime"                expression => isvariable("zmd_sections");
 
   processes:
 
-      "/usr/lib/zmd/zmd.exe"
-        restart_class => "zmd_restart";
+      "/usr/lib/zmd/zmd.exe"  restart_class => "zmd_restart";
 
   commands:
 
     showtime.SuSE.checkzmd_present::
-
       "${g.rudder_dependencies}/checkzmd.pl \"$(zmd_name[${zmd_index}])\" \"$(zmd_url[${zmd_index}])\" ${zmd_index}"
         contain => in_shell,
         module => "true",
         comment => "Analyzing ZMD's output";
 
     showtime.SuSE.zmd_repositories_edit::
-
       "/usr/bin/rug"
         args => "sa --type=zypp \"$(zmd_url[${zmd_index}])\" \"$(zmd_name[${zmd_index}])\"",
         ifvarclass => "index_${zmd_index}_not_matched",
@@ -109,13 +101,12 @@ bundle agent check_zmd_settings
         comment => "Subscribe ${zmd_index} as a new source";
 
     showtime.SuSE.(zmd_restart|zmd_conf_validated)::
-
       "/etc/init.d/novell-zmd"
         args => "restart",
         classes => kept_if_else("zmd_kept", "zmd_restarted", "could_not_restart_zmd"),
         comment => "Restart the ZMD daemon";
-  files:
 
+  files:
     showtime.SuSE::
       "/etc/zmd/zmd.conf"
         create => "true",
@@ -127,9 +118,7 @@ bundle agent check_zmd_settings
 
   reports:
 
-
     # ZMD settings edition
-
     zmd_conf_kept::
       "@@zmdPackageManagerSettings@@result_success@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#ZMD settings were all already correct";
 
@@ -140,14 +129,11 @@ bundle agent check_zmd_settings
       "@@zmdPackageManagerSettings@@result_error@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#ZMD repositories could not be edited";
 
     # Ignore non-SuSE OSes
-
     !SuSE::
       "@@zmdPackageManagerSettings@@result_error@@&TRACKINGKEY&@@zmdPackageManagerSettings@@None@@${g.execRun}##${g.uuid}@#ZMD cannot be configured on non SuSE OSes";
 
     SuSE::
-
       # Repositories
-
       "@@zmdPackageManagerSettings@@result_success@@&TRACKINGKEY&@@Repository@@$(zmd_url[${zmd_index}])@@${g.execRun}##${g.uuid}@#The ZMD source $(zmd_name[${zmd_index}]) is not here but no edition required. Skipping..."
         ifvarclass => "index_${zmd_index}_not_matched.!zmd_repositories_edit";
 
@@ -165,7 +151,6 @@ bundle agent check_zmd_settings
 
 
       # ZMD Process presence related reports
-
       "@@zmdPackageManagerSettings@@result_success@@&TRACKINGKEY&@@ZMD process@@None@@${g.execRun}##${g.uuid}@#The ZMD process is present. Skipping ..."
         ifvarclass => "!zmd_restart";
 
@@ -177,54 +162,52 @@ bundle agent check_zmd_settings
 
 }
 
-
 bundle edit_line set_advanced_zmd_config_values(tab, sectionName)
 {
- # Sets the RHS of configuration items in the file of the form
- # LHS=RHS
- # If the line is commented out with #, it gets uncommented first.
- # Adds a new line if none exists.
- # The argument is an associative array containing tab[SectionName][LHS]="RHS"
- # don't change value when the RHS is dontchange
+# Sets the RHS of configuration items in the file of the form
+# LHS=RHS
+# If the line is commented out with #, it gets uncommented first.
+# Adds a new line if none exists.
+# The argument is an associative array containing tab[SectionName][LHS]="RHS"
+# don't change value when the RHS is dontchange
 
  # Based on set_variable_values from cfengine_stdlib.cf, modified to
  # use section to define were to write, and to handle commented-out lines.
 
  # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
- # otherwise you may risk a segfault
+ # otherwise you may risk a segfault 
 
   vars:
-      "index" slist => getindices("${tab}[${sectionName}]");
 
-  # Be careful if the index string contains funny chars
-      "cindex[${index}]" string => canonify("${index}");
+      "index"            slist  => getindices("$(tab)[$(sectionName)]");
+
+       # Be careful if the index string contains funny chars
+      "cindex[$(index)]" string => canonify("$(index)");
 
   classes:
-      "edit_$(cindex[${index}])" not => strcmp("$(${tab}[${sectionName}][${index}])","dontchange");
+
+      "edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
 
   field_edits:
 
-  # If the line is there, but commented out, first uncomment it
-      "#+${index}=.*"
-        select_region => INI_section("${sectionName}"),
-        edit_field => col("=","1","${index}","set"),
-        ifvarclass => "edit_$(cindex[${index}])";
+      # If the line is there, but commented out, first uncomment it
+      "#+$(index)=.*"
+        select_region => INI_section("$(sectionName)"),
+        edit_field    => col("=","1","$(index)","set"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
-  # match a line starting like the key something
-      "${index}=.*"
-        edit_field => col("=","2","$(${tab}[${sectionName}][${index}])","set"),
-        select_region => INI_section("${sectionName}"),
-        classes => if_ok("not_$(cindex[${index}])"),
-        ifvarclass => "edit_$(cindex[${index}])";
+      # match a line starting like the key something
+      "$(index)=.*"
+        edit_field    => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+        select_region => INI_section("$(sectionName)"),
+        classes       => if_ok("not_$(cindex[$(index)])"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
   insert_lines:
-      "[${sectionName}]"
-        location => start;
 
-      "${index}=$(${tab}[${sectionName}][${index}])",
-        select_region => INI_section("${sectionName}"),
-        ifvarclass => "!not_$(cindex[${index}]).edit_$(cindex[${index}])";
+      "[$(sectionName)]" location => start;
 
+      "$(index)=$($(tab)[$(sectionName)][$(index)])",
+        select_region => INI_section("$(sectionName)"),
+        ifvarclass    => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 }
-
-

--- a/techniques/applications/zmdPackageManagerSettings/2.0/metadata.xml
+++ b/techniques/applications/zmdPackageManagerSettings/2.0/metadata.xml
@@ -1,0 +1,170 @@
+<!--
+Copyright 2011 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<TECHNIQUE name="RUG / YaST package manager configuration (ZMD)">
+  <DESCRIPTION>This technique configures the RUG and YaST package manager using Novell's ZMD.</DESCRIPTION>
+  <MULTIINSTANCE>false</MULTIINSTANCE>
+  <COMPATIBLE>
+    <OS version=">= 10 SP1 (Agama Lizard)">SuSE LES / DES / OpenSuSE</OS>
+    <AGENT version=">= 3.2.0">cfengine-community</AGENT>
+  </COMPATIBLE>
+
+  <BUNDLES>
+    <NAME>check_zmd_settings</NAME>
+  </BUNDLES>
+
+  <TMLS>
+    <TML name="zmdPackageManagerSettings"/>
+  </TMLS>
+  
+  <TRACKINGVARIABLE>
+    <SAMESIZEAS>ZMD_SOURCEPOLICY</SAMESIZEAS>
+  </TRACKINGVARIABLE>
+    
+  <SECTIONS>
+    <SECTION name="ZMD process" component="true" />
+    <!-- General settings Section , index 1-->
+    <SECTION name="General settings" component="true">
+      <SELECT1>
+        <NAME>ZMD_SOURCEPOLICY</NAME>
+        <DESCRIPTION>Package sources policy</DESCRIPTION>
+        <LONGDESCRIPTION>This option defines which component of a repository is used as a trusted reference for the packages. Signature checks the package against the repository PGP key and Checksum only checks the package integrity. None installs the packages blindly without checking them.</LONGDESCRIPTION>
+        <ITEM>
+          <VALUE>signature</VALUE>
+          <LABEL>Signature</LABEL>
+        </ITEM>
+        <ITEM>
+          <VALUE>checksum</VALUE>
+          <LABEL>Checksum</LABEL>
+        </ITEM>
+        <ITEM>
+          <VALUE>none</VALUE>
+          <LABEL>Nothing</LABEL>
+        </ITEM>
+        <ITEM>
+          <VALUE>dontchange</VALUE>
+          <LABEL>Don't change</LABEL>
+        </ITEM>
+        <CONSTRAINT>
+          <DEFAULT>dontchange</DEFAULT>
+        </CONSTRAINT>
+      </SELECT1>
+
+    <!-- Proxy settings Section , index 10 -->
+      <INPUT>
+        <NAME>ZMD_PROXY_URL</NAME>
+        <DESCRIPTION>Proxy URL</DESCRIPTION>
+        <LONGDESCRIPTION>The URL should be in the following format: http://[user:password@]server[:port]/</LONGDESCRIPTION>
+        <CONSTRAINT>
+          <MAYBEEMPTY>true</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+      <INPUT>
+        <NAME>ZMD_PROXY_USER</NAME>
+        <DESCRIPTION>Proxy username</DESCRIPTION>
+        <LONGDESCRIPTION>This should be the username used to connect to the proxy, if required</LONGDESCRIPTION>
+        <CONSTRAINT>
+          <MAYBEEMPTY>true</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+      <INPUT>
+        <NAME>ZMD_PROXY_PASSWORD</NAME>
+        <DESCRIPTION>Proxy password</DESCRIPTION>
+        <LONGDESCRIPTION>This should be the password used to connect to the proxy, if required</LONGDESCRIPTION>
+        <CONSTRAINT>
+          <MAYBEEMPTY>true</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+    </SECTION>
+
+	  <SECTION name="Advanced repository settings">
+		<INPUT>
+		    <NAME>ZMD_SET_REFRESH_INTERVAL</NAME>
+		    <DESCRIPTION>Set the refresh interval</DESCRIPTION>
+		    <CONSTRAINT>
+		      <TYPE>boolean</TYPE>
+		      <DEFAULT>false</DEFAULT>
+		    </CONSTRAINT>
+		</INPUT>
+
+        <INPUT>
+          <NAME>ZMD_REFRESH_INTERVAL</NAME>
+          <DESCRIPTION>How long between refreshes, in seconds</DESCRIPTION>
+          <CONSTRAINT>
+			<TYPE>integer</TYPE>
+			<DEFAULT>86400</DEFAULT>
+          </CONSTRAINT>
+        </INPUT>
+
+		<SELECT1>
+          <NAME>ZMD_REMOTE_ENABLED</NAME>
+          <DESCRIPTION>Allow clients to connect remotely to this daemon</DESCRIPTION>
+          <ITEM>
+		      <LABEL>True</LABEL>
+		      <VALUE>True</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>False</LABEL>
+		      <VALUE>False</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Don't change</LABEL>
+		      <VALUE>dontchange</VALUE>
+		  </ITEM>
+		  <CONSTRAINT>
+		    <DEFAULT>dontchange</DEFAULT>
+		  </CONSTRAINT>
+        </SELECT1>
+
+		<SELECT1>
+          <NAME>ZMD_SYSLOG_LEVEL</NAME>
+          <DESCRIPTION>Logging level (off, fatal, error, warn, info, debug)</DESCRIPTION>
+          <ITEM>
+		      <LABEL>Off</LABEL>
+		      <VALUE>off</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Fatal</LABEL>
+		      <VALUE>fatal</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Error</LABEL>
+		      <VALUE>error</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Warn</LABEL>
+		      <VALUE>warn</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Info</LABEL>
+		      <VALUE>info</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Debug</LABEL>
+		      <VALUE>debug</VALUE>
+		  </ITEM>
+		  <ITEM>
+		      <LABEL>Don't change</LABEL>
+		      <VALUE>dontchange</VALUE>
+		  </ITEM>
+		  <CONSTRAINT>
+		    <DEFAULT>dontchange</DEFAULT>
+		  </CONSTRAINT>
+        </SELECT1>
+	  </SECTION>
+
+  </SECTIONS>
+
+</TECHNIQUE>

--- a/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
+++ b/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
@@ -20,140 +20,130 @@
 # Configures the RUG/YaST Package Managers using ZMD #
 ######################################################
 
-bundle agent check_zmd_settings {
+bundle agent check_zmd_settings
+{
+  vars:
 
-	vars:
+    proxy_edit::
+      "zmdconf[Network][proxy-url]"      string => "&ZMD_PROXY_URL&";
 
-		proxy_edit::
+    proxy_edit_user::
+      "zmdconf[Network][proxy-username]" string => "&ZMD_PROXY_USER&";
 
-			"zmdconf[Network][proxy-url]" string => "&ZMD_PROXY_URL&";
+    proxy_edit_password::
+      "zmdconf[Network][proxy-password]" string => "&ZMD_PROXY_PASSWORD&";
 
-		proxy_edit_user::
-
-			"zmdconf[Network][proxy-username]" string => "&ZMD_PROXY_USER&";
-
-		proxy_edit_password::
-
-			"zmdconf[Network][proxy-password]" string => "&ZMD_PROXY_PASSWORD&";
-
-		class_ok::
-
-                &TRACKINGKEY:{directiveId |"zmdconf_uuid[&i&]" string => "&directiveId&";
+    class_ok::
+      &TRACKINGKEY:{directiveId |"zmdconf_uuid[&i&]" string => "&directiveId&";
 }&
 
 &if(ZMD_SET_REFRESH_INTERVAL)&
-		"zmdconf[Server][refresh-interval]" string => "&ZMD_REFRESH_INTERVAL&";
+      "zmdconf[Server][refresh-interval]" string => "&ZMD_REFRESH_INTERVAL&";
 &endif&
-		"zmdconf[Advanced][security-level]" string => "&ZMD_SOURCEPOLICY&";
+      "zmdconf[Advanced][security-level]" string => "&ZMD_SOURCEPOLICY&";
 
-		"zmdconf[Server][remote-enabled]" string => "&ZMD_REMOTE_ENABLED&";
+      "zmdconf[Server][remote-enabled]"   string => "&ZMD_REMOTE_ENABLED&";
 
-		"zmdconf[Debug][syslog-level]" string => "&ZMD_SYSLOG_LEVEL&";
+      "zmdconf[Debug][syslog-level]"      string => "&ZMD_SYSLOG_LEVEL&";
 
-		"zmd_sections" slist => getindices("zmdconf");
-		"zmd_index" slist => getindices("zmdconf_uuid");
+      "zmd_sections"                      slist  => getindices("zmdconf");
+      "zmd_index"                         slist  => getindices("zmdconf_uuid");
 
-	classes:
+  classes:
 
-		# Do we want to set the proxy ?
-		"proxy_edit" not => strcmp("&ZMD_PROXY_URL&", "");
+      # Do we want to set the proxy ?
+      "proxy_edit"          not => strcmp("&ZMD_PROXY_URL&", "");
 
-		# Do we want to set the proxy username ?
-		"proxy_edit_user" not => strcmp("&ZMD_PROXY_USER&", "");
+      # Do we want to set the proxy username ?
+      "proxy_edit_user"     not => strcmp("&ZMD_PROXY_USER&", "");
 
-		# Do we want to set the proxy username ?
-		"proxy_edit_password" not => strcmp("&ZMD_PROXY_PASSWORD&", "");
+      # Do we want to set the proxy username ?
+      "proxy_edit_password" not => strcmp("&ZMD_PROXY_PASSWORD&", "");
 
-		# Check if any settings have to be checked
-		"security_level_edit" not => strcmp("&ZMD_SOURCEPOLICY&", "dontchange");
-		"remote_enabled_edit" not => strcmp("&ZMD_REMOTE_ENABLED&", "dontchange");
-		"syslog_level_edit"   not => strcmp("&ZMD_SYSLOG_LEVEL&", "dontchange");
-		"settings_edition"    or  => {
-						"proxy_edit",
-						"proxy_edit_user",
-						"proxy_edit_password",
-						"security_level_edit",
-						"remote_enabled_edit",
-						"syslog_level_edit"
-						};
+      # Check if any settings have to be checked
+      "security_level_edit" not => strcmp("&ZMD_SOURCEPOLICY&", "dontchange");
+      "remote_enabled_edit" not => strcmp("&ZMD_REMOTE_ENABLED&", "dontchange");
+      "syslog_level_edit"   not => strcmp("&ZMD_SYSLOG_LEVEL&", "dontchange");
+      "settings_edition"    or  => {
+                                     "proxy_edit",
+                                     "proxy_edit_user",
+                                     "proxy_edit_password",
+                                     "security_level_edit",
+                                     "remote_enabled_edit",
+                                     "syslog_level_edit"
+                                     };
 
-		"class_ok" expression => strcmp("true", "true");
+      "class_ok" expression => strcmp("true", "true");
 
-	processes:
+  processes:
 
-		"/usr/lib/zmd/zmd.exe"
-			restart_class => "zmd_restart";
+     "/usr/lib/zmd/zmd.exe" restart_class => "zmd_restart";
 
-	commands:
+  commands:
 
-		settings_edition.SuSE.checkzmd_present::
+    settings_edition.SuSE.checkzmd_present::
+      "${g.rudder_dependencies}/checkzmd.pl \"$(zmd_name[$(zmd_index)])\" \"$(zmd_url[$(zmd_index)])\" $(zmd_index)"
+        contain => in_shell,
+        module => "true",
+        comment => "Analyzing ZMD's output";
 
-			"${g.rudder_dependencies}/checkzmd.pl \"$(zmd_name[$(zmd_index)])\" \"$(zmd_url[$(zmd_index)])\" $(zmd_index)"
-				contain => in_shell,
-				module => "true",
-				comment => "Analyzing ZMD's output";
+    settings_edition.SuSE.(zmd_restart|zmd_conf_validated)::
+      "/etc/init.d/novell-zmd"
+        args => "restart",
+        classes => kept_if_else("zmd_kept", "zmd_restarted", "could_not_restart_zmd"),
+        comment => "Restart the ZMD daemon";
 
-		settings_edition.SuSE.(zmd_restart|zmd_conf_validated)::
+  files:
 
-			"/etc/init.d/novell-zmd"
-				args => "restart",
-				classes => kept_if_else("zmd_kept", "zmd_restarted", "could_not_restart_zmd"),
-				comment => "Restart the ZMD daemon";
-	files:
+    settings_edition.SuSE::
+      "/etc/zmd/zmd.conf"
+        create => "true",
+        perms => mog("600", "root", "root"),
+        edit_defaults => noempty_backup,
+        edit_line => set_advanced_zmd_config_values("check_zmd_settings.zmdconf", "$(zmd_sections)"),
+        classes => kept_if_else("zmd_conf_kept", "zmd_conf_validated", "zmd_conf_failed");
 
-		settings_edition.SuSE::
-			"/etc/zmd/zmd.conf"
-				create => "true",
-				perms => mog("600", "root", "root"),
-				edit_defaults => noempty_backup,
-				edit_line => set_advanced_zmd_config_values("check_zmd_settings.zmdconf", "$(zmd_sections)"),
-				classes => kept_if_else("zmd_conf_kept", "zmd_conf_validated", "zmd_conf_failed");
+  reports:
 
-	reports:
+    # ZMD settings edition
+    !settings_edition::
+      "@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#No ZMD settings were specified. Skipping...";
 
+    zmd_conf_kept::
+      "@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD settings were all already correct";
 
-		# ZMD settings edition
+    zmd_conf_validated::
+      "@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some ZMD settings were reset";
 
-		!settings_edition::
-			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#No ZMD settings were specified. Skipping...";
+    zmd_conf_failed::
+      "@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD repositories could not be edited";
 
-		zmd_conf_kept::
-			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD settings were all already correct";
+    # Ignore non-SuSE OSes
+    !SuSE::
+      "@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
 
-		zmd_conf_validated::
-			"@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some ZMD settings were reset";
+    SuSE::
+    # ZMD Process presence related reports
+      "@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD process is present. Skipping ..."
+        ifvarclass => "!zmd_restart";
 
-		zmd_conf_failed::
-			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD repositories could not be edited";
+      "@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon was successfully restarted"
+        ifvarclass => "zmd_restarted";
 
-		# Ignore non-SuSE OSes
-
-		!SuSE::
-			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
-
-		SuSE::
-
-			# ZMD Process presence related reports
-
-			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD process is present. Skipping ..."
-				ifvarclass => "!zmd_restart";
-
-			"@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon was successfully restarted"
-				ifvarclass => "zmd_restarted";
-
-			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon failed to restart"
-				ifvarclass => "could_not_restart_zmd";
+      "@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon failed to restart"
+        ifvarclass => "could_not_restart_zmd";
 
 }
 
 
-bundle edit_line set_advanced_zmd_config_values(tab, sectionName) {
- # Sets the RHS of configuration items in the file of the form
- # LHS=RHS
- # If the line is commented out with #, it gets uncommented first.
- # Adds a new line if none exists.
- # The argument is an associative array containing tab[SectionName][LHS]="RHS"
- # don't change value when the RHS is dontchange
+bundle edit_line set_advanced_zmd_config_values(tab, sectionName)
+{
+# Sets the RHS of configuration items in the file of the form
+# LHS=RHS
+# If the line is commented out with #, it gets uncommented first.
+# Adds a new line if none exists.
+# The argument is an associative array containing tab[SectionName][LHS]="RHS"
+# don't change value when the RHS is dontchange
 
  # Based on set_variable_values from cfengine_stdlib.cf, modified to
  # use section to define were to write, and to handle commented-out lines.
@@ -161,38 +151,37 @@ bundle edit_line set_advanced_zmd_config_values(tab, sectionName) {
  # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
  # otherwise you may risk a segfault 
 
- vars:
-  "index" slist => getindices("$(tab)[$(sectionName)]");
+  vars:
 
-  # Be careful if the index string contains funny chars
-  "cindex[$(index)]" string => canonify("$(index)");
+      "index"            slist  => getindices("$(tab)[$(sectionName)]");
 
- classes:
-	"edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
+       # Be careful if the index string contains funny chars
+      "cindex[$(index)]" string => canonify("$(index)");
 
-field_edits:
+  classes:
 
-  # If the line is there, but commented out, first uncomment it
-  "#+$(index)=.*"
- 	 select_region => INI_section("$(sectionName)"),
-     edit_field => col("=","1","$(index)","set"),
-	 ifvarclass => "edit_$(cindex[$(index)])";
+      "edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
 
-  # match a line starting like the key something
-  "$(index)=.*"
-     edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
-		select_region => INI_section("$(sectionName)"),
-       	classes => if_ok("not_$(cindex[$(index)])"),
-		ifvarclass => "edit_$(cindex[$(index)])";
+  field_edits:
 
-insert_lines:
-	"[$(sectionName)]"
-		location => start;
+      # If the line is there, but commented out, first uncomment it
+      "#+$(index)=.*"
+        select_region => INI_section("$(sectionName)"),
+        edit_field    => col("=","1","$(index)","set"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
-	"$(index)=$($(tab)[$(sectionName)][$(index)])",
-		select_region => INI_section("$(sectionName)"),
-		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+      # match a line starting like the key something
+      "$(index)=.*"
+        edit_field    => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+        select_region => INI_section("$(sectionName)"),
+        classes       => if_ok("not_$(cindex[$(index)])"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
+  insert_lines:
+
+      "[$(sectionName)]" location => start;
+
+      "$(index)=$($(tab)[$(sectionName)][$(index)])",
+        select_region => INI_section("$(sectionName)"),
+        ifvarclass    => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 }
-
-

--- a/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
+++ b/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
@@ -1,0 +1,199 @@
+#####################################################################################
+# Copyright 2011 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+######################################################
+# Configures the RUG/YaST Package Managers using ZMD #
+######################################################
+
+bundle agent check_zmd_settings {
+
+	vars:
+
+		proxy_edit::
+
+			"zmdconf[Network][proxy-url]" string => "&ZMD_PROXY_URL&";
+
+		proxy_edit_user::
+
+			"zmdconf[Network][proxy-username]" string => "&ZMD_PROXY_USER&";
+
+		proxy_edit_password::
+
+			"zmdconf[Network][proxy-password]" string => "&ZMD_PROXY_PASSWORD&";
+
+		class_ok::
+
+                &TRACKINGKEY:{directiveId |"zmdconf_uuid[&i&]" string => "&directiveId&";
+}&
+
+&if(ZMD_SET_REFRESH_INTERVAL)&
+		"zmdconf[Server][refresh-interval]" string => "&ZMD_REFRESH_INTERVAL&";
+&endif&
+		"zmdconf[Advanced][security-level]" string => "&ZMD_SOURCEPOLICY&";
+
+		"zmdconf[Server][remote-enabled]" string => "&ZMD_REMOTE_ENABLED&";
+
+		"zmdconf[Debug][syslog-level]" string => "&ZMD_SYSLOG_LEVEL&";
+
+		"zmd_sections" slist => getindices("zmdconf");
+		"zmd_index" slist => getindices("zmdconf_uuid");
+
+	classes:
+
+		# Do we want to set the proxy ?
+		"proxy_edit" not => strcmp("&ZMD_PROXY_URL&", "");
+
+		# Do we want to set the proxy username ?
+		"proxy_edit_user" not => strcmp("&ZMD_PROXY_USER&", "");
+
+		# Do we want to set the proxy username ?
+		"proxy_edit_password" not => strcmp("&ZMD_PROXY_PASSWORD&", "");
+
+		# Check if any settings have to be checked
+		"security_level_edit" not => strcmp("&ZMD_SOURCEPOLICY&", "dontchange");
+		"remote_enabled_edit" not => strcmp("&ZMD_REMOTE_ENABLED&", "dontchange");
+		"syslog_level_edit"   not => strcmp("&ZMD_SYSLOG_LEVEL&", "dontchange");
+		"settings_edition"    or  => {
+						"proxy_edit",
+						"proxy_edit_user",
+						"proxy_edit_password",
+						"security_level_edit",
+						"remote_enabled_edit",
+						"syslog_level_edit",
+						"settings_edition"
+						};
+
+		"class_ok" expression => strcmp("true", "true");
+
+	processes:
+
+		"/usr/lib/zmd/zmd.exe"
+			restart_class => "zmd_restart";
+
+	commands:
+
+		settings_edition.SuSE.checkzmd_present::
+
+			"${g.rudder_dependencies}/checkzmd.pl \"$(zmd_name[$(zmd_index)])\" \"$(zmd_url[$(zmd_index)])\" $(zmd_index)"
+				contain => in_shell,
+				module => "true",
+				comment => "Analyzing ZMD's output";
+
+		settings_edition.SuSE.(zmd_restart|zmd_conf_validated)::
+
+			"/etc/init.d/novell-zmd"
+				args => "restart",
+				classes => kept_if_else("zmd_kept", "zmd_restarted", "could_not_restart_zmd"),
+				comment => "Restart the ZMD daemon";
+	files:
+
+		settings_edition.SuSE::
+			"/etc/zmd/zmd.conf"
+				create => "true",
+				perms => mog("600", "root", "root"),
+				edit_defaults => noempty_backup,
+				edit_line => set_advanced_zmd_config_values("check_zmd_settings.zmdconf", "$(zmd_sections)"),
+				classes => kept_if_else("zmd_conf_kept", "zmd_conf_validated", "zmd_conf_failed");
+
+	reports:
+
+
+		# ZMD settings edition
+
+		!settings_edition::
+			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#No ZMD settings were specified. Skipping...";
+
+		zmd_conf_kept::
+			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD settings were all already correct";
+
+		zmd_conf_validated::
+			"@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some ZMD settings were reset";
+
+		zmd_conf_failed::
+			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD repositories could not be edited";
+
+		# Ignore non-SuSE OSes
+
+		!SuSE::
+			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@zmdPackageManagerSettings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+
+		SuSE::
+
+			# ZMD Process presence related reports
+
+			"@@zmdPackageManagerSettings@@result_success@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD process is present. Skipping ..."
+				ifvarclass => "!zmd_restart";
+
+			"@@zmdPackageManagerSettings@@result_repaired@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon was successfully restarted"
+				ifvarclass => "zmd_restarted";
+
+			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@ZMD process@@None@@$(g.execRun)##$(g.uuid)@#The ZMD daemon failed to restart"
+				ifvarclass => "could_not_restart_zmd";
+
+}
+
+
+bundle edit_line set_advanced_zmd_config_values(tab, sectionName) {
+ # Sets the RHS of configuration items in the file of the form
+ # LHS=RHS
+ # If the line is commented out with #, it gets uncommented first.
+ # Adds a new line if none exists.
+ # The argument is an associative array containing tab[SectionName][LHS]="RHS"
+ # don't change value when the RHS is dontchange
+
+ # Based on set_variable_values from cfengine_stdlib.cf, modified to
+ # use section to define were to write, and to handle commented-out lines.
+
+ # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
+ # otherwise you may risk a segfault 
+
+ vars:
+  "index" slist => getindices("$(tab)[$(sectionName)]");
+
+  # Be careful if the index string contains funny chars
+  "cindex[$(index)]" string => canonify("$(index)");
+
+ classes:
+	"edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
+
+field_edits:
+
+  # If the line is there, but commented out, first uncomment it
+  "#+$(index)=.*"
+ 	 select_region => INI_section("$(sectionName)"),
+     edit_field => col("=","1","$(index)","set"),
+	 ifvarclass => "edit_$(cindex[$(index)])";
+
+  # match a line starting like the key something
+  "$(index)=.*"
+     edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+		select_region => INI_section("$(sectionName)"),
+       	classes => if_ok("not_$(cindex[$(index)])"),
+		ifvarclass => "edit_$(cindex[$(index)])";
+
+insert_lines:
+	"[$(sectionName)]"
+		location => start;
+
+	"$(index)=$($(tab)[$(sectionName)][$(index)])",
+		select_region => INI_section("$(sectionName)"),
+		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+
+}
+
+

--- a/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
+++ b/techniques/applications/zmdPackageManagerSettings/2.0/zmdPackageManagerSettings.st
@@ -74,8 +74,7 @@ bundle agent check_zmd_settings {
 						"proxy_edit_password",
 						"security_level_edit",
 						"remote_enabled_edit",
-						"syslog_level_edit",
-						"settings_edition"
+						"syslog_level_edit"
 						};
 
 		"class_ok" expression => strcmp("true", "true");
@@ -130,7 +129,7 @@ bundle agent check_zmd_settings {
 		# Ignore non-SuSE OSes
 
 		!SuSE::
-			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@zmdPackageManagerSettings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+			"@@zmdPackageManagerSettings@@result_error@@${zmdconf_uuid[${zmd_index}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
 
 		SuSE::
 

--- a/techniques/applications/zypperPackageManagerSettings/1.0/zypperPackageManagerSettings.st
+++ b/techniques/applications/zypperPackageManagerSettings/1.0/zypperPackageManagerSettings.st
@@ -22,34 +22,33 @@
 
 bundle agent check_zypper_settings
 {
-
   vars:
 
-    &ZYPPER_NAME:{zypper_name |"zypper_name[&i&]" string => "&zypper_name&";
+      &ZYPPER_NAME:{zypper_name |"zypper_name[&i&]" string => "&zypper_name&";
 }&
-    &ZYPPER_URL:{zypper_url |"zypper_url[&i&]" string => "&zypper_url&";
+      &ZYPPER_URL:{zypper_url |"zypper_url[&i&]" string => "&zypper_url&";
 }&
-    &ZYPPER_TYPE:{zypper_type |"zypper_type[&i&]" string => "&zypper_type&";
+      &ZYPPER_TYPE:{zypper_type |"zypper_type[&i&]" string => "&zypper_type&";
 }&
-    &ZYPPER_ENABLED:{zypper_enabled |"zypper_enabled[&i&]" string => "&zypper_enabled&";
+      &ZYPPER_ENABLED:{zypper_enabled |"zypper_enabled[&i&]" string => "&zypper_enabled&";
 }&
 
-                # List of all the files to permit on the vhost directory
-      "zypper_files" slist => { &ZYPPER_NAME: { "rudder-&it&.repo" };separator=", "&};
+      # List of all the files to permit on the vhost directory
+      "zypper_files"                       slist => { &ZYPPER_NAME: { "rudder-&it&.repo" };separator=", "&};
 
-      "zypper_index" slist => getindices("zypper_name");
+      "zypper_index"                       slist => getindices("zypper_name");
 
       "zmdconf[main][solver.onlyRequires]" string => "&ZYPPER_INSTALLRECOMMENDS&";
 
-      "zypper_sections" slist => getindices("zmdconf");
+      "zypper_sections"                    slist => getindices("zmdconf");
 
   classes:
 
-    # Repositories edition ?
-      "zypper_repositories_edit" expression => strcmp("&ZYPPER_ADDREPOSITORIES&","true");
+      # Repositories edition ?
+      "zypper_repositories_edit"   expression => strcmp("&ZYPPER_ADDREPOSITORIES&","true");
 
-    # Disable repositories ?
-      "zypper_disablerepositories" not => strcmp("&ZYPPER_DISABLEREPOSITORIES&","false");
+      # Disable repositories ?
+      "zypper_disablerepositories" not        => strcmp("&ZYPPER_DISABLEREPOSITORIES&","false");
 
   files:
 
@@ -62,23 +61,27 @@ bundle agent check_zypper_settings
         classes => kept_if_else("zypper_conf_kept", "zypper_conf_validated", "zypper_conf_failed");
 
     SuSE.zypper_repositories_edit::
-
-                        #"/etc/zypp/repos.d/rudder-defined.repo"
-                        #        create => "true",
-                        #        perms => m("644"),
-                        #        edit_line => set_zypper_repos("check_zypper_settings.zypper_name", "check_zypper_settings.zypper_url", "check_zypper_settings.zypper_enabled", "check_zypper_settings.zypper_type"),
-                        #        edit_defaults => empty_backup,
-                        #        classes =>  kept_if_else("zypper_tier1_kept", "zypper_tier1_validated", "zypper_tier1_failed");
+      #"/etc/zypp/repos.d/rudder-defined.repo"
+      #  create => "true",
+      #  perms => m("644"),
+      #  edit_line => set_zypper_repos("check_zypper_settings.zypper_name", "check_zypper_settings.zypper_url", "check_zypper_settings.zypper_enabled", "check_zypper_settings.zypper_type"),
+      #  edit_defaults => empty_backup,
+      #  classes =>  kept_if_else("zypper_tier1_kept", "zypper_tier1_validated", "zypper_tier1_failed");
 
       "/etc/zypp/repos.d/rudder-$(zypper_name[${zypper_index}]).repo"
         create => "true",
         perms => m("644"),
-        edit_line => set_zypper_repos("$(zypper_name[${zypper_index}])", "$(zypper_url[${zypper_index}])", "$(zypper_enabled[${zypper_index}])", "$(zypper_type[${zypper_index}])", "${g.rudder_dependencies}/zypper-repo.tpl"),
+        edit_line => set_zypper_repos(
+                                       "$(zypper_name[${zypper_index}])",
+                                        "$(zypper_url[${zypper_index}])",
+                                        "$(zypper_enabled[${zypper_index}])",
+                                        "$(zypper_type[${zypper_index}])",
+                                        "${g.rudder_dependencies}/zypper-repo.tpl"
+                                        ),
         edit_defaults => empty_backup,
         classes => kept_if_else("zypper_${zypper_index}_kept", "zypper_${zypper_index}_validated", "zypper_${zypper_index}_failed");
 
     SuSE.zypper_disablerepositories::
-
       "/etc/zypp/repos.d/.*"
         delete => tidy,
         file_select => ex_list("@{zypper_files}"),
@@ -89,7 +92,6 @@ bundle agent check_zypper_settings
   reports:
 
     # ZYPPER settings edition
-
     zypper_conf_kept::
       "@@zypperPackageManagerSettings@@result_success@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#Zypper settings were all already correct";
 
@@ -100,7 +102,6 @@ bundle agent check_zypper_settings
       "@@zypperPackageManagerSettings@@result_error@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#Zypper repositories could not be edited";
 
     # Zypper repositories desactivation
-
     zypper_disablerepositories.!repos_disabled_ok.!repos_disabled_fail::
       "@@zypperPackageManagerSettings@@result_success@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#Every repository other than the defined ones were already disabled";
 
@@ -114,18 +115,14 @@ bundle agent check_zypper_settings
       "@@zypperPackageManagerSettings@@result_success@@&TRACKINGKEY&@@General settings@@None@@${g.execRun}##${g.uuid}@#The repository desactivation has not been requested. Skipping...";
 
     # Ignore non-SuSE OSes
-
     !SuSE::
       "@@zypperPackageManagerSettings@@result_error@@&TRACKINGKEY&@@zypperPackageManagerSettings@@None@@${g.execRun}##${g.uuid}@#ZYPPER cannot be configured on non SuSE OSes";
 
     !zypper_repositories_edit::
-
       "@@zypperPackageManagerSettings@@result_success@@&TRACKINGKEY&@@Repository@@$(zypper_name[${zypper_index}])@@${g.execRun}##${g.uuid}@#The source $(zypper_name[${zypper_index}]) will NOT be added as the repository addition parameter is off in the Policy Instance. Skipping...";
 
     SuSE::
-
-                # Repositories
-
+      # Repositories
       "@@zypperPackageManagerSettings@@result_success@@&TRACKINGKEY&@@Repository@@$(zypper_name[${zypper_index}])@@${g.execRun}##${g.uuid}@#The Zypper source $(zypper_name[${zypper_index}]) was already here. Skipping..."
         ifvarclass => "zypper_${zypper_index}_kept.!zypper_${zypper_index}_validated";
 
@@ -134,13 +131,10 @@ bundle agent check_zypper_settings
 
       "@@zypperPackageManagerSettings@@result_error@@&TRACKINGKEY&@@Repository@@$(zypper_name[${zypper_index}])@@${g.execRun}##${g.uuid}@#The Zypper source $(zypper_name[${zypper_index}]) was NOT added!"
         ifvarclass => "zypper_${zypper_index}_error";
-
-
 }
 
 bundle edit_line set_zypper_repos(zypper_name, zypper_url, zypper_enabled, zypper_type, template)
 {
-
   insert_lines:
 
       "${template}"
@@ -158,7 +152,7 @@ bundle edit_line set_zypper_repos_BROKEN(zypper_name, zypper_url, zypper_enabled
 
   insert_lines:
 
-        "#############################################################
+      "#############################################################
 ### This file is protected by your Rudder infrastructure. ###
 ### Manually editing the file might lead your Rudder      ###
 ### infrastructure to change back the server’s            ###
@@ -211,52 +205,54 @@ bundle edit_line set_zypper_repos_BROKEN(zypper_name, zypper_url, zypper_enabled
 
 bundle edit_line set_advanced_zypper_config_values(tab, sectionName)
 {
- # Sets the RHS of configuration items in the file of the form
- # LHS=RHS
- # If the line is commented out with #, it gets uncommented first.
- # Adds a new line if none exists.
- # The argument is an associative array containing tab[SectionName][LHS]="RHS"
- # don't change value when the RHS is dontchange
+# Sets the RHS of configuration items in the file of the form
+# LHS=RHS
+# If the line is commented out with #, it gets uncommented first.
+# Adds a new line if none exists.
+# The argument is an associative array containing tab[SectionName][LHS]="RHS"
+# don't change value when the RHS is dontchange
 
  # Based on set_variable_values from cfengine_stdlib.cf, modified to
  # use section to define were to write, and to handle commented-out lines.
 
  # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
- # otherwise you may risk a segfault
+ # otherwise you may risk a segfault 
 
   vars:
-      "index" slist => getindices("${tab}[${sectionName}]");
 
-  # Be careful if the index string contains funny chars
-      "cindex[${index}]" string => canonify("${index}");
+      "index"            slist => getindices("$(tab)[$(sectionName)]");
+
+      # Be careful if the index string contains funny chars
+      "cindex[$(index)]" string => canonify("$(index)");
 
   classes:
-      "edit_$(cindex[${index}])" not => strcmp("$(${tab}[${sectionName}][${index}])","dontchange");
+
+      "edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
 
   field_edits:
 
-  # If the line is there, but commented out, first uncomment it
-      "#+${index}=.*"
-        select_region => INI_section("${sectionName}"),
-        edit_field => col("=","1","${index}","set"),
-        ifvarclass => "edit_$(cindex[${index}])";
+      # If the line is there, but commented out, first uncomment it
+      "#+$(index)=.*"
+        select_region => INI_section("$(sectionName)"),
+        edit_field    => col("=","1","$(index)","set"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
-  # match a line starting like the key something
-      "${index}=.*"
-        edit_field => col("=","2","$(${tab}[${sectionName}][${index}])","set"),
-        select_region => INI_section("${sectionName}"),
-        classes => if_ok("not_$(cindex[${index}])"),
-        ifvarclass => "edit_$(cindex[${index}])";
+      # match a line starting like the key something
+      "$(index)=.*"
+        edit_field    => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+        select_region => INI_section("$(sectionName)"),
+        classes       => if_ok("not_$(cindex[$(index)])"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
   insert_lines:
-      "${index}=$(${tab}[${sectionName}][${index}])",
-        select_region => INI_section("${sectionName}"),
-        ifvarclass => "!not_$(cindex[${index}]).edit_$(cindex[${index}])";
 
+      "$(index)=$($(tab)[$(sectionName)][$(index)])",
+        select_region => INI_section("$(sectionName)"),
+        ifvarclass    => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 }
 
 body file_select not_rudderzypperrepo
 {
-        leaf_name => { "^[^rudder-defined.*?\.repo].*" };
-        file_result => "leaf_name";
+  leaf_name => { "^[^rudder-defined.*?\.repo].*" };
+  file_result => "leaf_name";
 }

--- a/techniques/applications/zypperPackageManagerSettings/2.0/metadata.xml
+++ b/techniques/applications/zypperPackageManagerSettings/2.0/metadata.xml
@@ -1,0 +1,62 @@
+<!--
+Copyright 2011 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<TECHNIQUE name="Zypper package manager configuration">
+  <DESCRIPTION>This technique configure the Zypper package manager.</DESCRIPTION>
+
+  <MULTIINSTANCE>false</MULTIINSTANCE>
+
+  <COMPATIBLE>
+    <OS version=">= 10 SP1 (Agama Lizard)">SuSE LES / DES / OpenSuSE</OS>
+    <AGENT version=">= 3.2.0">cfengine-community</AGENT>
+  </COMPATIBLE>
+
+  <BUNDLES>
+    <NAME>check_zypper_settings</NAME>
+  </BUNDLES>
+
+  <TMLS>
+    <TML name="zypperPackageManagerSettings"/>
+  </TMLS>
+
+  <TRACKINGVARIABLE>
+  </TRACKINGVARIABLE>
+  
+  <SECTIONS>
+    <!-- General settings Section , index 1-->
+    <SECTION name="General settings" component="true">
+      <SELECT1>
+        <NAME>ZYPPER_INSTALLRECOMMENDS</NAME>
+        <DESCRIPTION>Install 'recommended' packages automatically</DESCRIPTION>
+        <ITEM>
+          <VALUE>dontchange</VALUE>
+          <LABEL>Don't change</LABEL>
+        </ITEM>
+        <ITEM>
+          <VALUE>true</VALUE>
+          <LABEL>Yes</LABEL>
+        </ITEM>
+        <ITEM>
+          <VALUE>false</VALUE>
+          <LABEL>No</LABEL>
+        </ITEM>
+        <CONSTRAINT>
+          <DEFAULT>dontchange</DEFAULT>
+        </CONSTRAINT>
+      </SELECT1>
+    </SECTION>
+  </SECTIONS>
+
+</TECHNIQUE>

--- a/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
+++ b/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
@@ -1,0 +1,107 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+######################################################
+# Configures the Zypper Package Manager              #
+######################################################
+
+bundle agent check_zypper_settings {
+
+	vars:
+
+		"zypper_uuid" string => "&TRACKINGKEY&";
+
+		"zmdconf[main][solver.onlyRequires]" string => "&ZYPPER_INSTALLRECOMMENDS&";
+
+		"zypper_sections" slist => getindices("zmdconf");
+
+	files:
+
+		SuSE::
+			"/etc/zypp/zypp.conf"
+				create => "true",
+				perms => mog("644", "root", "root"),
+				edit_defaults => noempty_backup,
+				edit_line => set_advanced_zypper_config_values("check_zypper_settings.zmdconf", "$(zypper_sections)"),
+				classes => kept_if_else("zypper_conf_kept", "zypper_conf_validated", "zypper_conf_failed");
+
+	reports:
+
+		# ZYPPER settings edition
+
+		zypper_conf_kept::
+			"@@zypperPackageManagerSettings@@result_success@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper settings were all already correct";
+
+		zypper_conf_validated::
+			"@@zypperPackageManagerSettings@@result_repaired@@${zypper_uuid}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some Zypper settings were reset";
+
+		zypper_conf_failed::
+			"@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper repositories could not be edited";
+
+}
+
+bundle edit_line set_advanced_zypper_config_values(tab, sectionName) {
+ # Sets the RHS of configuration items in the file of the form
+ # LHS=RHS
+ # If the line is commented out with #, it gets uncommented first.
+ # Adds a new line if none exists.
+ # The argument is an associative array containing tab[SectionName][LHS]="RHS"
+ # don't change value when the RHS is dontchange
+
+ # Based on set_variable_values from cfengine_stdlib.cf, modified to
+ # use section to define were to write, and to handle commented-out lines.
+
+ # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
+ # otherwise you may risk a segfault 
+
+ vars:
+  "index" slist => getindices("$(tab)[$(sectionName)]");
+
+  # Be careful if the index string contains funny chars
+  "cindex[$(index)]" string => canonify("$(index)");
+
+ classes:
+	"edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
+
+field_edits:
+
+  # If the line is there, but commented out, first uncomment it
+  "#+$(index)=.*"
+ 	 select_region => INI_section("$(sectionName)"),
+     edit_field => col("=","1","$(index)","set"),
+	 ifvarclass => "edit_$(cindex[$(index)])";
+
+  # match a line starting like the key something
+  "$(index)=.*"
+     edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+		select_region => INI_section("$(sectionName)"),
+       	classes => if_ok("not_$(cindex[$(index)])"),
+		ifvarclass => "edit_$(cindex[$(index)])";
+
+insert_lines:
+	"$(index)=$($(tab)[$(sectionName)][$(index)])",
+		select_region => INI_section("$(sectionName)"),
+		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+
+}
+
+body file_select not_rudderzypperrepo
+{
+     leaf_name => { "^[^rudder-defined.*?\.repo].*" };
+     file_result => "leaf_name";
+}

--- a/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
+++ b/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
@@ -20,51 +20,50 @@
 # Configures the Zypper Package Manager              #
 ######################################################
 
-bundle agent check_zypper_settings {
+bundle agent check_zypper_settings
+{
+  vars:
 
-	vars:
+      "zypper_uuid"                        string => "&TRACKINGKEY&";
 
-		"zypper_uuid" string => "&TRACKINGKEY&";
+      "zmdconf[main][solver.onlyRequires]" string => "&ZYPPER_INSTALLRECOMMENDS&";
 
-		"zmdconf[main][solver.onlyRequires]" string => "&ZYPPER_INSTALLRECOMMENDS&";
+      "zypper_sections"                    slist  => getindices("zmdconf");
 
-		"zypper_sections" slist => getindices("zmdconf");
+  files:
 
-	files:
+    SuSE::
+      "/etc/zypp/zypp.conf"
+       create        => "true",
+       perms         => mog("644", "root", "root"),
+       edit_defaults => noempty_backup,
+       edit_line     => set_advanced_zypper_config_values("check_zypper_settings.zmdconf", "$(zypper_sections)"),
+       classes       => kept_if_else("zypper_conf_kept", "zypper_conf_validated", "zypper_conf_failed");
 
-		SuSE::
-			"/etc/zypp/zypp.conf"
-				create => "true",
-				perms => mog("644", "root", "root"),
-				edit_defaults => noempty_backup,
-				edit_line => set_advanced_zypper_config_values("check_zypper_settings.zmdconf", "$(zypper_sections)"),
-				classes => kept_if_else("zypper_conf_kept", "zypper_conf_validated", "zypper_conf_failed");
+  reports:
 
-	reports:
+    !SuSE::
+      "@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
 
-		!SuSE::
-			"@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+    # ZYPPER settings edition
+    zypper_conf_kept::
+      "@@zypperPackageManagerSettings@@result_success@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper settings were all already correct";
 
-		# ZYPPER settings edition
+    zypper_conf_validated::
+      "@@zypperPackageManagerSettings@@result_repaired@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some Zypper settings were reset";
 
-		zypper_conf_kept::
-			"@@zypperPackageManagerSettings@@result_success@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper settings were all already correct";
-
-		zypper_conf_validated::
-			"@@zypperPackageManagerSettings@@result_repaired@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some Zypper settings were reset";
-
-		zypper_conf_failed::
-			"@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper repositories could not be edited";
-
+    zypper_conf_failed::
+      "@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper repositories could not be edited";
 }
 
-bundle edit_line set_advanced_zypper_config_values(tab, sectionName) {
- # Sets the RHS of configuration items in the file of the form
- # LHS=RHS
- # If the line is commented out with #, it gets uncommented first.
- # Adds a new line if none exists.
- # The argument is an associative array containing tab[SectionName][LHS]="RHS"
- # don't change value when the RHS is dontchange
+bundle edit_line set_advanced_zypper_config_values(tab, sectionName)
+{
+# Sets the RHS of configuration items in the file of the form
+# LHS=RHS
+# If the line is commented out with #, it gets uncommented first.
+# Adds a new line if none exists.
+# The argument is an associative array containing tab[SectionName][LHS]="RHS"
+# don't change value when the RHS is dontchange
 
  # Based on set_variable_values from cfengine_stdlib.cf, modified to
  # use section to define were to write, and to handle commented-out lines.
@@ -72,39 +71,41 @@ bundle edit_line set_advanced_zypper_config_values(tab, sectionName) {
  # CAUTION : for it to work nicely, you should use Cfengine with the commit n°3229
  # otherwise you may risk a segfault 
 
- vars:
-  "index" slist => getindices("$(tab)[$(sectionName)]");
+  vars:
 
-  # Be careful if the index string contains funny chars
-  "cindex[$(index)]" string => canonify("$(index)");
+      "index"            slist => getindices("$(tab)[$(sectionName)]");
 
- classes:
-	"edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
+      # Be careful if the index string contains funny chars
+      "cindex[$(index)]" string => canonify("$(index)");
 
-field_edits:
+  classes:
 
-  # If the line is there, but commented out, first uncomment it
-  "#+$(index)=.*"
- 	 select_region => INI_section("$(sectionName)"),
-     edit_field => col("=","1","$(index)","set"),
-	 ifvarclass => "edit_$(cindex[$(index)])";
+      "edit_$(cindex[$(index)])" not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange");
 
-  # match a line starting like the key something
-  "$(index)=.*"
-     edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
-		select_region => INI_section("$(sectionName)"),
-       	classes => if_ok("not_$(cindex[$(index)])"),
-		ifvarclass => "edit_$(cindex[$(index)])";
+  field_edits:
 
-insert_lines:
-	"$(index)=$($(tab)[$(sectionName)][$(index)])",
-		select_region => INI_section("$(sectionName)"),
-		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
+      # If the line is there, but commented out, first uncomment it
+      "#+$(index)=.*"
+        select_region => INI_section("$(sectionName)"),
+        edit_field    => col("=","1","$(index)","set"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
 
+      # match a line starting like the key something
+      "$(index)=.*"
+        edit_field    => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
+        select_region => INI_section("$(sectionName)"),
+        classes       => if_ok("not_$(cindex[$(index)])"),
+        ifvarclass    => "edit_$(cindex[$(index)])";
+
+  insert_lines:
+
+      "$(index)=$($(tab)[$(sectionName)][$(index)])",
+        select_region => INI_section("$(sectionName)"),
+        ifvarclass    => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 }
 
 body file_select not_rudderzypperrepo
 {
-     leaf_name => { "^[^rudder-defined.*?\.repo].*" };
-     file_result => "leaf_name";
+  leaf_name => { "^[^rudder-defined.*?\.repo].*" };
+  file_result => "leaf_name";
 }

--- a/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
+++ b/techniques/applications/zypperPackageManagerSettings/2.0/zypperPackageManagerSettings.st
@@ -42,13 +42,16 @@ bundle agent check_zypper_settings {
 
 	reports:
 
+		!SuSE::
+			"@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#ZMD cannot be configured on non SuSE OSes";
+
 		# ZYPPER settings edition
 
 		zypper_conf_kept::
 			"@@zypperPackageManagerSettings@@result_success@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper settings were all already correct";
 
 		zypper_conf_validated::
-			"@@zypperPackageManagerSettings@@result_repaired@@${zypper_uuid}]}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some Zypper settings were reset";
+			"@@zypperPackageManagerSettings@@result_repaired@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Some Zypper settings were reset";
 
 		zypper_conf_failed::
 			"@@zypperPackageManagerSettings@@result_error@@${zypper_uuid}@@General settings@@None@@$(g.execRun)##$(g.uuid)@#Zypper repositories could not be edited";


### PR DESCRIPTION
Fixes #3313 - Rework indentations in Techniques 'RUG / YaST package manager configuration (ZMD)', 'Zypper package manager configuration','Package repositories management (Rug)' and 'Package repositories management (RPM)'

This PR depends from https://github.com/Normation/rudder-techniques/pull/56