### PR TITLE
Fixes #3439 - Remove from exclusion the cygwin code in fusionAgent.st

### DIFF
--- a/policies/system/inventory/1.0/fusionAgent.st
+++ b/policies/system/inventory/1.0/fusionAgent.st
@@ -287,6 +287,7 @@ bundle agent addInformationsToInventory {
 		"RUDDERUUID" string => execresult("${sys.winsysdir}\cscript.exe /Nologo \"${g.rudder_dependencies}/uuid.vbs\"","noshell");
 		"polserv_uuid" string => readfile( "$(g.rudder_var_tmp)\uuid.txt" , "33" );
 		"users" slist => { readstringlist("${inventory.UserListFile}","#.*","[\n| |\r]",50,4000) };
+&endif&
 		
 	cygwin::
 		"mywinpath" string => execresult("/usr/bin/echo $WINDIR ", "useshell");
@@ -295,7 +296,6 @@ bundle agent addInformationsToInventory {
 		"RUDDERUUID" string => execresult("${sys.winsysdir}\cscript.exe /Nologo ${g.rudder_dependencies}/uuid.vbs","noshell");
 		"polserv_uuid" string => readfile( "$(g.rudder_var_tmp)/uuid.txt" , "33" );
 		"users" slist => { readstringlist("${inventory.UserListFile}","#.*","[\n| |\r]",10,4000) };
-&endif&
 
 	linux::
 		"RUDDERUUID" string => execresult("/usr/sbin/dmidecode -s system-uuid","noshell");


### PR DESCRIPTION
Fixes #3439 - Remove from exclusion the cygwin code in fusionAgent.st
