### PR TITLE
skipidentify for android

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -458,6 +458,9 @@ body agent control {
 	(android|linux)::
 		default_repository => "${g.rudder_var}/modified-files";
 
+    # we can not depend on DNS for mobile devices
+    android::
+        skipidentify => "true";
 }
 
 #######################################################

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -531,6 +531,10 @@ body agent control {
     (android|linux)::
 	default_repository => "${g.rudder_var}/modified-files";
 
+    # we can not depend on DNS for mobile devices
+    android::
+        skipidentify => "true";
+
 &if(NOVA)&
 #    windows::
 #	default_repository => "c:\Program Files\Rudder\modified-files";


### PR DESCRIPTION
mobile devices are rarely registered in DNS.
