### PR TITLE
Fixes #3526: Add a git lock age checking promise to the distributePolicy...

### DIFF
--- a/techniques/system/distributePolicy/1.0/integrityCheck.st
+++ b/techniques/system/distributePolicy/1.0/integrityCheck.st
@@ -28,7 +28,7 @@ bundle agent root_integrity_check {
     "${g.rudder_var}/configuration-repository/.git/index.lock"
       delete       => tidy,
       file_select  => rudder_common_minutes_old("5"),
-      classes      => rudder_common_classes("rudder_git_lock"");
+      classes      => rudder_common_classes("rudder_git_lock"),
       comment      => "Delete the git locking file in the configuration-repository if older than 5 minutes";
 
 	reports:


### PR DESCRIPTION
... (@# borken class definition)

To be merged in 2.5

Ticket: http://www.rudder-project.org/redmine/issues/3526
