### PR TITLE
Fixes #3561: Use unanchored cron paths because anchored ones break

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -347,15 +347,15 @@ bundle agent check_cron_daemon
   vars:
 
     redhat::
-      "cron_bin" string => "^crond$";
+      "cron_bin" string => "crond";
       "cron_restartcmd" string => "/etc/init.d/crond restart";
 
     ubuntu::
-      "cron_bin" string => "^cron$";
+      "cron_bin" string => "cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
     !(redhat.ubuntu)::
-      "cron_bin" string => "^/usr/sbin/cron$";
+      "cron_bin" string => "/usr/sbin/cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
   processes:

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -444,15 +444,15 @@ bundle agent check_cron_daemon
   vars:
 
     redhat::
-      "cron_bin" string => "^crond$";
+      "cron_bin" string => "crond";
       "cron_restartcmd" string => "/etc/init.d/crond restart";
 
     ubuntu::
-      "cron_bin" string => "^cron$";
+      "cron_bin" string => "cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
     !(redhat.ubuntu)::
-      "cron_bin" string => "^/usr/sbin/cron$";
+      "cron_bin" string => "/usr/sbin/cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
   processes:

--- a/techniques/systemSettings/systemManagement/cronManagement/1.0/cronConfiguration.st
+++ b/techniques/systemSettings/systemManagement/cronManagement/1.0/cronConfiguration.st
@@ -58,15 +58,15 @@ bundle agent check_cron_configuration
       "normalorderingtwist" string => "done";
 
     redhat::
-      "cron_bin"        string => "^crond$";
+      "cron_bin"        string => "crond";
       "cron_restartcmd" string => "/etc/init.d/crond restart";
 
     ubuntu::
-      "cron_bin"        string => "^cron$";
+      "cron_bin"        string => "cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
     !(redhat.ubuntu)::
-      "cron_bin"        string => "^/usr/sbin/cron$";
+      "cron_bin"        string => "/usr/sbin/cron";
       "cron_restartcmd" string => "/etc/init.d/cron restart";
 
   processes:


### PR DESCRIPTION
To be merged in master

Ticket: http://www.rudder-project.org/redmine/issues/3561
