### PR TITLE
Fixes #3570: Use the cfengine hard classes to decide between the old and...

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -102,27 +102,35 @@ bundle agent init_files {
 # than 1 hour, remove cf_lock.db (and only this DB), to give CFEngine a chance
 # to run properly again.
 bundle agent check_lock_db_problem{
-    files:
-        # The aim of this promise is to create a class when this file is older
-        # than one hour. The class can not be created without touching but in
-        # order to not modifing the mtime we use warn_only.
-        "${sys.workdir}/last_successful_inputs_update"
-            file_select => over_an_hour,
-            touch       => "true",
-            action      => warn_only,
-            classes     => success("last_successful_inputs_update_too_old", "last_successful_inputs_update_check_error", "last_successful_inputs_update_ok");
+  vars:
 
-        "${sys.workdir}/state/cf_lock.db"
-            delete     => tidy,
-            ifvarclass => "last_successful_inputs_update_too_old",
-            classes    => success("cf_lock_removed", "cf_lock_error_removing", "cf_lock_not_deleted");
+    cfengine_3_0|cfengine_3_1|cfengine_3_2::
+      "cf_lock_filename" string => "cf_lock.db";
 
-    reports:
-        cf_lock_removed::
-            "@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@$(g.execRun)##$(g.uuid)@#Promises had not been updated for over an hour, this could indicate a broken lockfile. cf_lock.db was removed.";
+    !(cfengine_3_0|cfengine_3_1|cfengine_3_2)::
+      "cf_lock_filename" string => "cf_lock.tcdb";
 
-        cf_lock_error_removing::
-            "@@Common@@result_error@@&TRACKINGKEY&@@Update@@None@@$(g.execRun)##$(g.uuid)@#Promises have not been updated for over an hour, this could indicate a broken lockfile, but an error occured when trying to remove it";
+  files:
+      # The aim of this promise is to create a class when this file is older
+      # than one hour. The class can not be created without touching but in
+      # order to not modifing the mtime we use warn_only.
+      "${sys.workdir}/last_successful_inputs_update"
+        file_select => over_an_hour,
+        touch       => "true",
+        action      => warn_only,
+        classes     => success("last_successful_inputs_update_too_old", "last_successful_inputs_update_check_error", "last_successful_inputs_update_ok");
+
+      "${sys.workdir}/state/${cf_lock_filename}"
+        delete     => tidy,
+        ifvarclass => "last_successful_inputs_update_too_old",
+        classes    => success("cf_lock_removed", "cf_lock_error_removing", "cf_lock_not_deleted");
+
+  reports:
+    cf_lock_removed::
+      "@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Promises had not been updated for over an hour, this could indicate a broken lockfile. cf_lock DB file was removed.";
+
+    cf_lock_error_removing::
+      "@@Common@@result_error@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Promises have not been updated for over an hour, this could indicate a broken lockfile, but an error occured when trying to remove it";
 }
 
 body file_select over_an_hour()

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -113,27 +113,35 @@ bundle agent init_files {
 # than 1 hour, remove cf_lock.db (and only this DB), to give CFEngine a chance
 # to run properly again.
 bundle agent check_lock_db_problem{
-	files:
-		# The aim of this promise is to create a class when this file is older
-		# than one hour. The class can not be created without touching but in
-		# order to not modifing the mtime we use warn_only.
-		"${sys.workdir}/last_successful_inputs_update"
-			file_select => over_an_hour,
-			touch       => "true",
-			action      => warn_only,
-			classes     => success("last_successful_inputs_update_too_old", "last_successful_inputs_update_check_error", "last_successful_inputs_update_ok");
+  vars:
 
-		"${sys.workdir}/state/cf_lock.db"
-			delete     => tidy,
-			ifvarclass => "last_successful_inputs_update_too_old",
-			classes    => success("cf_lock_removed", "cf_lock_error_removing", "cf_lock_not_deleted");
+    cfengine_3_0|cfengine_3_1|cfengine_3_2::
+      "cf_lock_filename" string => "cf_lock.db";
 
-	reports:
-		cf_lock_removed::
-			"@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@$(g.execRun)##$(g.uuid)@#Promises had not been updated for over an hour, this could indicate a broken lockfile. cf_lock.db was removed.";
+    !(cfengine_3_0|cfengine_3_1|cfengine_3_2)::
+      "cf_lock_filename" string => "cf_lock.tcdb";
 
-		cf_lock_error_removing::
-			"@@Common@@result_error@@&TRACKINGKEY&@@Update@@None@@$(g.execRun)##$(g.uuid)@#Promises have not been updated for over an hour, this could indicate a broken lockfile, but an error occured when trying to remove it";
+  files:
+      # The aim of this promise is to create a class when this file is older
+      # than one hour. The class can not be created without touching but in
+      # order to not modifing the mtime we use warn_only.
+      "${sys.workdir}/last_successful_inputs_update"
+        file_select => over_an_hour,
+        touch       => "true",
+        action      => warn_only,
+        classes     => success("last_successful_inputs_update_too_old", "last_successful_inputs_update_check_error", "last_successful_inputs_update_ok");
+
+      "${sys.workdir}/state/${cf_lock_filename}"
+        delete     => tidy,
+        ifvarclass => "last_successful_inputs_update_too_old",
+        classes    => success("cf_lock_removed", "cf_lock_error_removing", "cf_lock_not_deleted");
+
+  reports:
+    cf_lock_removed::
+      "@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Promises had not been updated for over an hour, this could indicate a broken lockfile. cf_lock DB file was removed.";
+
+    cf_lock_error_removing::
+      "@@Common@@result_error@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Promises have not been updated for over an hour, this could indicate a broken lockfile, but an error occured when trying to remove it";
 }
 
 body file_select over_an_hour()


### PR DESCRIPTION
... new db format (cf_lock verification)

To be merged in 2.4

Ticket: http://www.rudder-project.org/redmine/issues/3570
