### PR TITLE
Fixes #3581: Any copyFileFromSharedFolder Directive applied on a policy ...

### DIFF
--- a/initial-promises/node-server/common/1.0/rudder_lib.cf
+++ b/initial-promises/node-server/common/1.0/rudder_lib.cf
@@ -56,6 +56,25 @@ community_edition::
  	portnumber => "5309";
 }
 
+# This is an evolved version of copy_from scp that uses local copies if we are
+# running on a policy server instead of copying from a localhost remote blindly.
+body copy_from rudder_copy_from(from, server,compare,trustkey,preserve,purge) {
+
+    source   => "$(from)";
+
+    compare  => "$(compare)";
+    encrypt  => "true";
+    verify   => "true";
+    trustkey => "${trustkey}";
+    preserve => "${preserve}"; # Preserve the permissions
+    purge    => "${purge}";
+
+  !is_policy_server::
+    servers  => { "${server}" };
+
+  community_edition::
+    portnumber => "5309";
+}
 
 body copy_from copy(from) {
 	source => "$(from)";

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/common/core-lib.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/common/core-lib.cf
@@ -59,6 +59,26 @@ community_edition::
  	portnumber => "5309";
 }
 
+# This is an evolved version of copy_from scp that uses local copies if we are
+# running on a policy server instead of copying from a localhost remote blindly.
+body copy_from rudder_copy_from(from, server,compare,trustkey,preserve,purge) {
+
+    source   => "$(from)";
+
+    compare  => "$(compare)";
+    encrypt  => "true";
+    verify   => "true";
+    trustkey => "${trustkey}";
+    preserve => "${preserve}"; # Preserve the permissions
+    purge    => "${purge}";
+
+  !is_policy_server::
+    servers  => { "${server}" };
+
+  community_edition::
+    portnumber => "5309";
+}
+
 body copy_from copy(from) {
 	source => "$(from)";
 	copy_backup => "false";

--- a/techniques/fileDistribution/copyGitFile/1.1/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.1/copyFileFromSharedFolder.st
@@ -55,7 +55,7 @@ bundle agent download_from_shared_folder {
 	  is_valid::
 		
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "digest", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "digest", "false", "false", "false"),
 			depth_search => recurse("$(copyfile[$(index)][recursion])"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
@@ -66,7 +66,7 @@ bundle agent download_from_shared_folder {
 
 		# If it's a file, the depth_search prevents from enforcing the file content
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "digest", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "digest", "false", "false", "false"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
 					   , "$(copyfile[$(index)][group])"),

--- a/techniques/fileDistribution/copyGitFile/1.2/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.2/copyFileFromSharedFolder.st
@@ -58,7 +58,7 @@ bundle agent download_from_shared_folder {
 	  is_valid::
 		
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
 			depth_search => recurse("$(copyfile[$(index)][recursion])"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
@@ -69,7 +69,7 @@ bundle agent download_from_shared_folder {
 
 		# If it's a file, the depth_search prevents from enforcing the file content
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
 					   , "$(copyfile[$(index)][group])"),

--- a/techniques/fileDistribution/copyGitFile/1.3/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.3/copyFileFromSharedFolder.st
@@ -66,7 +66,7 @@ bundle agent download_from_shared_folder {
 	  is_valid::
 		
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
 			depth_search => recurse("$(copyfile[$(index)][recursion])"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
@@ -77,7 +77,7 @@ bundle agent download_from_shared_folder {
 
 		# If it's a file, the depth_search prevents from enforcing the file content
 		"$(copyfile[$(index)][destination])"
-			copy_from => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
+			copy_from => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
 			perms => mog("$(copyfile[$(index)][perm])"
 					   , "$(copyfile[$(index)][owner])"
 					   , "$(copyfile[$(index)][group])"),

--- a/techniques/fileDistribution/copyGitFile/1.4/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.4/copyFileFromSharedFolder.st
@@ -91,7 +91,7 @@ bundle agent download_from_shared_folder
     is_valid.iteration_2::
 
       "${copyfile[${index}][destination]}"
-        copy_from    => scp("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
+        copy_from    => rudder_copy_from("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
         depth_search => recurse("${copyfile[${index}][recursion]}"),
         perms        => mog(
                             "${copyfile[${index}][perm]}",
@@ -107,7 +107,7 @@ bundle agent download_from_shared_folder
     # is too dangerous to apply suid or sgid recursively and only copy an empty
     # directory does not make sense.
       "${copyfile[${index}][destination]}"
-        copy_from  => scp("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
+        copy_from  => rudder_copy_from("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
         perms      => mog(
                           "${extended_modes_${index}}${copyfile[${index}][perm]}",
                           "${copyfile[${index}][owner]}",

--- a/techniques/fileDistribution/copyGitFile/1.5/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.5/copyFileFromSharedFolder.st
@@ -102,7 +102,7 @@ bundle agent download_from_shared_folder
 
       # If it's a directory, without exclusion
       "$(copyfile[$(index)][destination])"
-        copy_from    => scp("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
+        copy_from    => rudder_copy_from("&SHARED_FILES_FOLDER&/$(copyfile[$(index)][name])", "$(server_info.cfserved)", "$(copyfile[$(index)][compare_method])", "false", "false", "false"),
         depth_search => recurse("$(copyfile[$(index)][recursion])"),
         perms        => mog(
                             "$(copyfile[$(index)][perm])",
@@ -115,7 +115,7 @@ bundle agent download_from_shared_folder
 
        # If it's a directory, with exclusion
       "${copyfile[${index}][destination]}"
-        copy_from    => scp("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
+        copy_from    => rudder_copy_from("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
         depth_search => recurse("${copyfile[${index}][recursion]}"),
         file_select  => exclude("${copyfile[${index}][exclude_include]}"),
         perms        => mog(
@@ -129,7 +129,7 @@ bundle agent download_from_shared_folder
 
        # If it's a directory, with inclusion
       "${copyfile[${index}][destination]}"
-        copy_from    => scp("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
+        copy_from    => rudder_copy_from("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
         depth_search => recurse("${copyfile[${index}][recursion]}"),
         file_select  => by_name("${copyfile[${index}][exclude_include]}"),
         perms        => mog(
@@ -146,7 +146,7 @@ bundle agent download_from_shared_folder
     # is too dangerous to apply suid or sgid recursively and only copy an empty
     # directory does not make sense.
       "${copyfile[${index}][destination]}"
-        copy_from  => scp("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
+        copy_from  => rudder_copy_from("&SHARED_FILES_FOLDER&/${copyfile[${index}][name]}", "${server_info.cfserved}", "${copyfile[${index}][compare_method]}", "false", "false", "false"),
         perms      => mog(
                           "${extended_modes_${index}}${copyfile[${index}][perm]}",
                           "${copyfile[${index}][owner]}",

--- a/techniques/system/common/1.0/rudder_lib.st
+++ b/techniques/system/common/1.0/rudder_lib.st
@@ -56,6 +56,25 @@ community_edition::
  	portnumber => "&COMMUNITYPORT&";
 }
 
+# This is an evolved version of copy_from scp that uses local copies if we are
+# running on a policy server instead of copying from a localhost remote blindly.
+body copy_from rudder_copy_from(from, server,compare,trustkey,preserve,purge) {
+
+    source   => "$(from)";
+
+    compare  => "$(compare)";
+    encrypt  => "true";
+    verify   => "true";
+    trustkey => "${trustkey}";
+    preserve => "${preserve}"; # Preserve the permissions
+    purge    => "${purge}";
+
+  !is_policy_server::
+    servers  => { "${server}" };
+
+  community_edition::
+    portnumber => "&COMMUNITYPORT&";
+}
 
 body copy_from copy(from) {
 	source => "$(from)";


### PR DESCRIPTION
...server will now be using a local copy instead of a remote one

Ticket: http://www.rudder-project.org/redmine/issues/3581

To be applied on the 2.4 branch
