### PR TITLE
Fixes #3811 - Fix missing double quote which broke 'Enforce a file content' v3.0

### DIFF
--- a/techniques/fileDistribution/checkGenericFileContent/3.0/checkGenericFileContent.st
+++ b/techniques/fileDistribution/checkGenericFileContent/3.0/checkGenericFileContent.st
@@ -114,7 +114,7 @@ bundle agent check_generic_file_content
 
       # Replace the matching line(s) of the file by an empty line
       # if replacement is not set
-      ${generic_file_content_path[${index}]}"
+      "${generic_file_content_path[${index}]}"
         edit_line => set_arbitrary_file_content_modify("${generic_file_content_modification_regexp[${index}]}", ""),
         create => "true",
         classes => kept_if_else("content_modification_kept_${index}", "content_modification_modified_${index}", "content_modification_failed_${index}"),


### PR DESCRIPTION
Fixes #3811 - Fix missing double quote which broke 'Enforce a file content' v3.0
