### PR TITLE
Fixes #3531,#3899: Backport the GIT lock nuking promise from 2.5

### DIFF
--- a/techniques/system/distributePolicy/1.0/integrityCheck.st
+++ b/techniques/system/distributePolicy/1.0/integrityCheck.st
@@ -25,6 +25,12 @@ bundle agent root_integrity_check {
                                 action => WarnOnly,
                                 classes => if_else("rudder_integrity_ok", "rudder_integrity_failed");
 
+    "${g.rudder_var}/configuration-repository/.git/index.lock"
+      delete       => tidy,
+      file_select  => rudder_common_minutes_old("5"),
+      classes      => rudder_common_classes("rudder_git_lock"),
+      comment      => "Delete the git locking file in the configuration-repository if older than 5 minutes";
+
 	reports:
 
 		linux::
@@ -34,5 +40,14 @@ bundle agent root_integrity_check {
 
 			"@@DistributePolicy@@result_error@@&TRACKINGKEY&@@Check configuration-repository folder@@None@@$(g.execRun)##$(g.uuid)@#EMERGENCY: THE $(g.rudder_var)/configuration-repository DIRECTORY IS *ABSENT*. THIS ORCHESTRATOR WILL *NOT* OPERATE CORRECTLY."
 				ifvarclass => "!rudder_integrity_ok|rudder_integrity_failed";
+
+    !rudder_git_lock_repaired.!rudder_git_lock_failed::
+      "@@DistributePolicy@@result_success@@&TRACKINGKEY&@@Check configuration-repository GIT lock@@None@@${g.execRun}##${g.uuid}@#The ${g.rudder_var}/configuration-repository GIT lock file is not present or not older than 5 minutes";
+
+    rudder_git_lock_repaired.!rudder_git_lock_failed::
+      "@@DistributePolicy@@result_repaired@@&TRACKINGKEY&@@Check configuration-repository GIT lock@@None@@${g.execRun}##${g.uuid}@#WARNING: THE ${g.rudder_var}/configuration-repository GIT LOCK FILE WAS OLDER THAN 5 MINUTES AND HAS BEEN DELETED";
+
+    rudder_git_lock_failed::
+      "@@DistributePolicy@@result_error@@&TRACKINGKEY&@@Check configuration-repository GIT lock@@None@@${g.execRun}##${g.uuid}@#TheEMERGENCY: THE ${g.rudder_var}/configuration-repository GIT LOCK FILE IS OLDER THAN 5 MINUTES AND COULD NOT BE DELETED. THIS ORCHESTRATOR WILL *NOT* OPERATE CORRECTLY.";
 
 }

--- a/techniques/system/distributePolicy/1.0/metadata.xml
+++ b/techniques/system/distributePolicy/1.0/metadata.xml
@@ -89,6 +89,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <SECTION name="Check PostgreSQL configuration" component="true"/>
     <SECTION name="Check logrotate configuration" component="true"/>
     <SECTION name="Check configuration-repository folder" component="true"/>
+    <SECTION name="Check configuration-repository GIT lock" component="true"/>
     <SECTION name="Check rudder-networks.conf file" component="true"/>
     <SECTION name="Check rudder status" component="true"/>
     <SECTION name="Check endpoint status" component="true"/>


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/3899

To be merged in 2.4
