### PR TITLE
Fixes #3908 - Remove backslash into rudder-agent cron file from intial promises

### DIFF
--- a/initial-promises/node-server/common/cron/rudder_agent_community_cron
+++ b/initial-promises/node-server/common/cron/rudder_agent_community_cron
@@ -5,4 +5,4 @@
 # To temporarily avoid this behaviour, touch /opt/rudder/etc/disable-agent.
 # Don't forget to remove that file when you're done!
 
-0,5,10,15,20,25,30,35,40,45,50,55 * * * * root if [ ! -e ${g.rudder_base}/etc/disable-agent -a `ps -efww | grep -E "(cf-execd|cf-agent)" | grep -E "${sys.workdir}/bin/(cf-execd|cf-agent)" | grep -v grep | wc -l` -eq 0 ]; then ${sys.workdir}/bin/cf-agent -f failsafe.cf \&\& ${sys.workdir}/bin/cf-agent; fi
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * root if [ ! -e ${g.rudder_base}/etc/disable-agent -a `ps -efww | grep -E "(cf-execd|cf-agent)" | grep -E "${sys.workdir}/bin/(cf-execd|cf-agent)" | grep -v grep | wc -l` -eq 0 ]; then ${sys.workdir}/bin/cf-agent -f failsafe.cf && ${sys.workdir}/bin/cf-agent; fi


### PR DESCRIPTION
Fixes #3908 - Remove backslash into rudder-agent cron file from intial promises

Reference : http://www.rudder-project.org/redmine/issues/3908
