### PR TITLE
Fixes #3931 - Change rudder-agent cron file to use /opt/rudder/bin/check-rudder-agent

### DIFF
--- a/initial-promises/node-server/common/cron/rudder_agent_community_cron
+++ b/initial-promises/node-server/common/cron/rudder_agent_community_cron
@@ -5,4 +5,4 @@
 # To temporarily avoid this behaviour, touch /opt/rudder/etc/disable-agent.
 # Don't forget to remove that file when you're done!
 
-0,5,10,15,20,25,30,35,40,45,50,55 * * * * root if [ ! -e ${g.rudder_base}/etc/disable-agent -a `ps -efww | grep -E "(cf-execd|cf-agent)" | grep -E "${sys.workdir}/bin/(cf-execd|cf-agent)" | grep -v grep | wc -l` -eq 0 ]; then ${sys.workdir}/bin/cf-agent -f failsafe.cf && ${sys.workdir}/bin/cf-agent; fi
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * root /opt/rudder/bin/check-rudder-agent

--- a/techniques/system/common/1.0/rudder_agent_community_cron.st
+++ b/techniques/system/common/1.0/rudder_agent_community_cron.st
@@ -5,4 +5,4 @@
 # To temporarily avoid this behaviour, touch /opt/rudder/etc/disable-agent.
 # Don't forget to remove that file when you're done!
 
-0,5,10,15,20,25,30,35,40,45,50,55 * * * * root if [ ! -e ${g.rudder_base}/etc/disable-agent -a `ps -efww | grep -E "(cf-execd|cf-agent)" | grep -E "${sys.workdir}/bin/(cf-execd|cf-agent)" | grep -v grep | wc -l` -eq 0 ]; then ${sys.workdir}/bin/cf-agent -f failsafe.cf \&\& ${sys.workdir}/bin/cf-agent; fi
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * root /opt/rudder/bin/check-rudder-agent


### PR DESCRIPTION
Fixes #3931 - Change rudder-agent cron file to use /opt/rudder/bin/check-rudder-agent

See http://www.rudder-project.org/redmine/issues/3930 and http://www.rudder-project.org/redmine/issues/3931

Need to be merged after https://github.com/Normation/rudder-packages/pull/119
