### PR TITLE
Fixes #3939 - Remove temporary cron file /opt/cron.d/rudder-agent-uuid

### DIFF
--- a/initial-promises/node-server/common/1.0/process_matching.cf
+++ b/initial-promises/node-server/common/1.0/process_matching.cf
@@ -74,6 +74,11 @@ files:
             create  => "true",
             edit_line => cron_add;
 
+      # Temporary cron file added by rudder-agent postinst to prevent from UUID removal.
+      # When this promise will be generated, this cron will be useless then removed.
+      # (see http://www.rudder-project.org/redmine/issues/3925 and http://www.rudder-project.org/redmine/issues/3930).
+      "/etc/cron.d/rudder-agent-uuid" delete => tidy;
+
 reports:
 
   restart_cf::

--- a/techniques/system/common/1.0/process_matching.st
+++ b/techniques/system/common/1.0/process_matching.st
@@ -88,6 +88,11 @@ files:
             create  => "true",
             edit_line => cron_add;
 
+      # Temporary cron file added by rudder-agent postinst to prevent from UUID removal.
+      # When this promise will be generated, this cron will be useless then removed.
+      # (see http://www.rudder-project.org/redmine/issues/3925 and http://www.rudder-project.org/redmine/issues/3930).
+      "/etc/cron.d/rudder-agent-uuid" delete => tidy;
+
 reports:
 
   restart_cf::


### PR DESCRIPTION
Fixes #3939 - Remove temporary cron file /opt/cron.d/rudder-agent-uuid

see http://www.rudder-project.org/redmine/issues/3938 and http://www.rudder-project.org/redmine/issues/3939
