### PR TITLE
Fixes #3871 - Remove comma after promisers in order to be compatible CFEngine 3.5

### DIFF
--- a/techniques/applications/apacheServer/1.0/apacheServerConfiguration.st
+++ b/techniques/applications/apacheServer/1.0/apacheServerConfiguration.st
@@ -491,7 +491,7 @@ delete_lines:
 
 insert_lines:
 
-        "$(index) $($(tab)[$(index)])",
+        "$(index) $($(tab)[$(index)])"
                 ifvarclass => "!not_$(cindex[$(index)])";
 
 }

--- a/techniques/applications/aptPackageManagerSettings/1.0/aptPackageManagerSettings.st
+++ b/techniques/applications/aptPackageManagerSettings/1.0/aptPackageManagerSettings.st
@@ -279,7 +279,7 @@ insert_lines:
                 location => start,
                 insert_type => "preserve_block";
 
-	"$(index) $($(tab)[$(index)])",
+	"$(index) $($(tab)[$(index)])"
 		ifvarclass => "!not_$(cindex[$(index)])";
 
 }

--- a/techniques/applications/openvpnClient/1.0/openvpnClientConfiguration.st
+++ b/techniques/applications/openvpnClient/1.0/openvpnClientConfiguration.st
@@ -264,7 +264,7 @@ insert_lines:
                 location => start,
                 insert_type => "preserve_block";
 
-	"$(index) $($(tab)[$(index)])",
+	"$(index) $($(tab)[$(index)])"
 		ifvarclass => "!not_$(cindex[$(index)])";
 
 }

--- a/techniques/applications/zmdPackageManagerSettings/1.0/zmdPackageManagerSettings.st
+++ b/techniques/applications/zmdPackageManagerSettings/1.0/zmdPackageManagerSettings.st
@@ -220,7 +220,7 @@ insert_lines:
 	"[$(sectionName)]"
 		location => start;
 
-	"$(index)=$($(tab)[$(sectionName)][$(index)])",
+	"$(index)=$($(tab)[$(sectionName)][$(index)])"
 		select_region => INI_section("$(sectionName)"),
 		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 

--- a/techniques/applications/zypperPackageManagerSettings/1.0/zypperPackageManagerSettings.st
+++ b/techniques/applications/zypperPackageManagerSettings/1.0/zypperPackageManagerSettings.st
@@ -249,7 +249,7 @@ field_edits:
 		ifvarclass => "edit_$(cindex[$(index)])";
 
 insert_lines:
-	"$(index)=$($(tab)[$(sectionName)][$(index)])",
+	"$(index)=$($(tab)[$(sectionName)][$(index)])"
 		select_region => INI_section("$(sectionName)"),
 		ifvarclass => "!not_$(cindex[$(index)]).edit_$(cindex[$(index)])";
 

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -568,13 +568,13 @@ bundle edit_line fix_syslogd(syslogd)
 {
     delete_lines:
 	any::
-            "^(local6)\s+(?!$(syslogd)).*",
+            "^(local6)\s+(?!$(syslogd)).*"
                 comment => "Delete missconfigured rudder syslogd destination";
 
     insert_lines:
 	any::
             "# Rudder specific logging parameters";
-            "local6.*						$(syslogd)",
+            "local6.*						$(syslogd)"
                 comment => "Add the rudder syslogd destination";
 }
 

--- a/techniques/system/common/1.0/rudder_lib.st
+++ b/techniques/system/common/1.0/rudder_lib.st
@@ -166,7 +166,7 @@ max_file_size => "1024000";
 bundle edit_line DeleteLinesMatching(regex) {
   delete_lines:
 
-    "$(regex)",
+    "$(regex)"
   action => WarnOnly;
 
 }

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -122,17 +122,17 @@ bundle agent update {
 
 		commands:
 			start_exec.!windows::
-				"$(sys.cf_execd)",
+				"$(sys.cf_execd)"
 				action => u_ifwin_bg,
 				classes => outcome("executor");
 
 			start_exec.cygwin::
-				"$(sys.cf_execd)",
+				"$(sys.cf_execd)"
 				action => u_ifwin_bg,
 				classes => outcome("executor");
 
 			start_server::
-				"$(sys.cf_serverd)",
+				"$(sys.cf_serverd)"
 				action => u_ifwin_bg,
 				classes => outcome("server");
 	

--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -149,7 +149,7 @@ bundle agent fusionAgent {
 
 	commands:
 	    linux.inventoryfoldercreated::
-			"${g.rudder_base}/bin/run-inventory --local=${g.rudder_var_tmp}/inventory --scan-homedirs",
+			"${g.rudder_base}/bin/run-inventory --local=${g.rudder_var_tmp}/inventory --scan-homedirs"
 			classes => cf2_if_else("run_inventory", "inventory_failed"),
 			comment => "Generating inventory, in the temporary folder";
 

--- a/techniques/systemSettings/remoteAccess/sshConfiguration/1.0/sshConfiguration.st
+++ b/techniques/systemSettings/remoteAccess/sshConfiguration/1.0/sshConfiguration.st
@@ -389,7 +389,7 @@ insert_lines:
                 location => start,
                 insert_type => "preserve_block";
 
-	"$(index) $($(tab)[$(index)])",
+	"$(index) $($(tab)[$(index)])"
 		ifvarclass => "!not_$(cindex[$(index)])";
 
 }

--- a/techniques/systemSettings/systemManagement/fstabConfiguration/1.0/fstabConfiguration.st
+++ b/techniques/systemSettings/systemManagement/fstabConfiguration/1.0/fstabConfiguration.st
@@ -150,7 +150,7 @@ field_edits:
 
 insert_lines:
 
-		"$($(data_array)[$(index)][origin]) $($(data_array)[$(index)][destination]) $($(data_array)[$(index)][filesystem]) $($(data_array)[$(index)][options]) $($(data_array)[$(index)][dump]) $($(data_array)[$(index)][fsckorder])",
+		"$($(data_array)[$(index)][origin]) $($(data_array)[$(index)][destination]) $($(data_array)[$(index)][filesystem]) $($(data_array)[$(index)][options]) $($(data_array)[$(index)][dump]) $($(data_array)[$(index)][fsckorder])"
 			ifvarclass => "addentry_$(index).!line_$(index)_added.!invalid_$(index)",
 			classes => kept_if_else("line_$(index)_kept", "line_$(index)_added", "line_$(index)_add_failed");
 reports:

--- a/techniques/systemSettings/systemManagement/fstabConfiguration/2.0/fstabConfiguration.st
+++ b/techniques/systemSettings/systemManagement/fstabConfiguration/2.0/fstabConfiguration.st
@@ -153,7 +153,7 @@ field_edits:
 
 insert_lines:
 
-		"$($(data_array)[$(index)][origin]) $($(data_array)[$(index)][destination]) $($(data_array)[$(index)][filesystem]) $($(data_array)[$(index)][options]) $($(data_array)[$(index)][dump]) $($(data_array)[$(index)][fsckorder])",
+		"$($(data_array)[$(index)][origin]) $($(data_array)[$(index)][destination]) $($(data_array)[$(index)][filesystem]) $($(data_array)[$(index)][options]) $($(data_array)[$(index)][dump]) $($(data_array)[$(index)][fsckorder])"
 			ifvarclass => "addentry_$(index).!line_$(index)_handled.!invalid_$(index)",
 			classes => kept_if_else("line_$(index)_kept", "line_$(index)_handled", "line_$(index)_handle_failed");
 


### PR DESCRIPTION
Fixes #3871 - Remove comma after promisers in order to be compatible CFEngine 3.5
