### PR TITLE
Fixes #4002 - Remove unused attributes 'owners' from body copy_from

### DIFF
--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -35,7 +35,6 @@ body copy_from remote(server, path) {
     preserve => "false"; #preserver permissions
     verify   => "true";
     purge    => "true";
-    owners   => {"&OWNER&"};
 community_edition::
                 portnumber => "&COMMUNITYPORT&";
 
@@ -54,7 +53,6 @@ body copy_from remote_unsecured(server, path) {
     preserve => "true"; #preserver permissions
     verify   => "true";
     purge    => "true";
-    owners   => {"&OWNER&"};
 community_edition::
                 portnumber => "&COMMUNITYPORT&";
 


### PR DESCRIPTION
Fixes #4002 - Remove unused attributes 'owners' from body copy_from

See http://www.rudder-project.org/redmine/issues/4002
