### PR TITLE
Fixes #4040 - Remove the comma after promiser which check the password of PostgreSQL

### DIFF
--- a/techniques/system/distributePolicy/1.0/passwordCheck.st
+++ b/techniques/system/distributePolicy/1.0/passwordCheck.st
@@ -160,7 +160,7 @@ bundle agent root_password_check_psql {
 
 		psql_cant_connect::
 
-			"/usr/bin/psql -q -c \"ALTER USER rudder WITH PASSWORD '$(p.psql_password[2])'\"",
+			"/usr/bin/psql -q -c \"ALTER USER rudder WITH PASSWORD '$(p.psql_password[2])'\""
 				contain => setuid_sh("postgres"),
 				classes => if_else("postgres_updated", "postgres_update_failed");
 


### PR DESCRIPTION
Fixes #4040 - Remove the comma after promiser which check the password of PostgreSQL

See http://www.rudder-project.org/redmine/issues/4040
