### PR TITLE
Fixes #4041 - Remove check of cf-report binary since it does not exist anymore

### DIFF
--- a/initial-promises/node-server/common/1.0/process_matching.cf
+++ b/initial-promises/node-server/common/1.0/process_matching.cf
@@ -23,7 +23,7 @@ bundle agent process_matching
  # This deliberately excludes cf-execd which is handled separately below
       "cf_components"       slist => { "cf-key",
                                   # "cf-monitord", Disabled
-      "cf-promises", "cf-report",
+      "cf-promises",
       "cf-runagent", "cf-serverd" };
 
     windows::

--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -73,7 +73,7 @@ bundle common rudder_roles
 bundle agent init_files
 {
   vars:
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key", "cf-hub" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "cf-hub" };
 
     nova_edition::
       "cfengine_install_path" string => "/usr/local";

--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -444,11 +444,11 @@ bundle agent check_binaries_freshness
 
     community_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key" };
 
     nova_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key", "cf-hub" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "cf-hub" };
 
   files:
 

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/common/process_matching.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/common/process_matching.cf
@@ -22,7 +22,7 @@ bundle agent process_matching
 
  # This deliberately excludes cf-execd which is handled separately below
       "cf_components"       slist => { "cf-key",
-      "cf-monitord", "cf-promises", "cf-report",
+      "cf-monitord", "cf-promises",
       "cf-runagent", "cf-serverd" };
 
     windows::

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/failsafe.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/failsafe.cf
@@ -57,7 +57,7 @@ bundle common g
 bundle agent init_files
 {
   vars:
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key", "cf-hub" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "cf-hub" };
 
     nova_edition::
       "cfengine_install_path" string => "/usr/local";

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -85,7 +85,7 @@ bundle common rudder_roles
 bundle agent init_files
 {
   vars:
-      "components"            slist  => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key", "cf-hub" };
+      "components"            slist  => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "cf-hub" };
 
     nova_edition::
       "cfengine_install_path" string => "/usr/local";

--- a/techniques/system/common/1.0/process_matching.st
+++ b/techniques/system/common/1.0/process_matching.st
@@ -25,7 +25,6 @@ bundle agent process_matching
         "cf-key",
         # "cf-monitord", Disabled
         "cf-promises",
-        "cf-report",
         "cf-runagent",
         "cf-serverd"
       };

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -609,11 +609,11 @@ bundle agent check_binaries_freshness
 
     community_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key" };
 
     nova_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-report", "cf-key", "cf-hub" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "cf-hub" };
 
   files:
 


### PR DESCRIPTION
Fixes #4041 - Remove check of cf-report binary since it does not exist anymore

See http://www.rudder-project.org/redmine/issues/4041
