### PR TITLE
Fixes #4039 - Move definition of the classes 'policy_server' and 'root_server' to bundle common which define bundlesquence in the initial promises

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -39,11 +39,6 @@ bundle common rudder_roles
   classes:
         # Abort if no uuid is defined
       "should_not_continue" not => fileexists("${uuid_file}");
-
-        # Policy Server is a machine which delivers promises
-      "policy_server" expression => strcmp("root","${uuid)");
-        # Root Server is the top policy server machine
-      "root_server" expression => strcmp("root","${uuid}");
 }
 
 body common control
@@ -96,6 +91,11 @@ bundle common va
      };
 
 # definition of the machine roles
+  classes:
+        # Policy Server is a machine which delivers promises
+      "policy_server" expression => strcmp("root","${uuid)");
+        # Root Server is the top policy server machine
+      "root_server" expression => strcmp("root","${uuid}");
 }
 
 #########################################################


### PR DESCRIPTION
Fixes #4039 - Move definition of the classes 'policy_server' and 'root_server' to bundle common which define bundlesquence in the initial promises

http://www.rudder-project.org/redmine/issues/4039
