### PR TITLE
Fixes #4042 - Remove comma after promiser in passwordcheck in initial promises

### DIFF
--- a/initial-promises/node-server/distributePolicy/1.0/passwordCheck.cf
+++ b/initial-promises/node-server/distributePolicy/1.0/passwordCheck.cf
@@ -165,7 +165,7 @@ bundle agent root_password_check_psql
 
     psql_cant_connect::
 
-      "/usr/bin/psql -q -c \"ALTER USER rudder WITH PASSWORD '${p.psql_password[2]}'\"",
+      "/usr/bin/psql -q -c \"ALTER USER rudder WITH PASSWORD '${p.psql_password[2]}'\""
         contain => setuid_sh("postgres"),
         classes => if_else("postgres_updated", "postgres_update_failed");
 


### PR DESCRIPTION
Fixes #4042 - Remove comma after promiser  in passwordcheck in initial promises

See http://www.rudder-project.org/redmine/issues/4042
