### PR TITLE
Fixes #4070 - Add 'package_patch_command' attributes in initial promises

### DIFF
--- a/initial-promises/node-server/common/1.0/cfengine_stdlib.cf
+++ b/initial-promises/node-server/common/1.0/cfengine_stdlib.cf
@@ -1585,6 +1585,7 @@ body package_method apt
         package_list_update_command => "/usr/bin/aptitude update";
         package_delete_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes -q remove";
         package_update_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes install";
+        package_patch_command =>  "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes install";
         package_verify_command => "/usr/bin/aptitude show";
         package_noverify_regex => "(State: not installed|E: Unable to locate package .*)";
 
@@ -1593,6 +1594,7 @@ body package_method apt
         package_list_update_command => "/usr/bin/apt-get update";
         package_delete_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes -q remove";
         package_update_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes install";
+        package_patch_command =>  "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes install";
         package_verify_command => "/usr/bin/dpkg -s";
         package_noverify_returncode => "1";
 }
@@ -1624,6 +1626,7 @@ body package_method dpkg_version(repo)
         package_add_command => "/usr/bin/dpkg --install";
         package_delete_command => "/usr/bin/dpkg --purge";
         package_update_command => "/usr/bin/dpkg --install";
+        package_patch_command =>  "/usr/bin/dpkg --install";
 }
 
 ##
@@ -1649,6 +1652,7 @@ body package_method rpm_version(repo)
 
         package_add_command => "/bin/rpm -ivh ";
         package_update_command => "/bin/rpm -Uvh ";
+        package_patch_command => "/bin/rpm -Uvh ";
         package_delete_command => "/bin/rpm -e --nodeps";
         package_noverify_regex => ".*[^\s].*";
 }
@@ -1741,6 +1745,7 @@ body package_method yum
 
         package_add_command => "/usr/bin/yum -y install";
         package_update_command => "/usr/bin/yum -y update";
+        package_patch_command => "/usr/bin/yum -y update";
         package_delete_command => "/bin/rpm -e --nodeps";
         package_verify_command => "/bin/rpm -V";
 }
@@ -1777,6 +1782,7 @@ body package_method yum_rpm
 
         package_add_command    => "/usr/bin/yum -y install";
         package_update_command => "/usr/bin/yum -y update";
+        package_patch_command => "/usr/bin/yum -y update";
         package_delete_command => "/bin/rpm -e --nodeps --allmatches";
         package_verify_command => "/bin/rpm -V";
 }
@@ -1850,6 +1856,7 @@ body package_method ips {
         package_list_update_command => "/usr/bin/pkg refresh --full";
         package_delete_command => "/usr/bin/pkg uninstall";
         package_update_command => "/usr/bin/pkg install --accept";
+        package_patch_command =>  "/usr/bin/pkg install --accept";
         package_verify_command => "/usr/bin/pkg list -a -v --no-refresh";
         package_noverify_regex => "(.*---|pkg list: no packages matching .* installed)";
 }
@@ -1945,6 +1952,7 @@ body package_method emerge
         package_add_command => "/usr/bin/emerge -q --quiet-build";
         package_delete_command => "/usr/bin/emerge --depclean";
         package_update_command => "/usr/bin/emerge --update";
+        package_patch_command => "/usr/bin/emerge --update";
         package_verify_command => "/usr/bin/emerge -s";
         package_noverify_regex => ".*(Not Installed|Applications found : 0).*";
 }
@@ -1989,6 +1997,7 @@ body package_method generic
         package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
         package_add_command    => "/usr/bin/yum -y install";
         package_update_command => "/usr/bin/yum -y update";
+        package_patch_command => "/usr/bin/yum -y update";
         package_delete_command => "/bin/rpm -e --nodeps --allmatches";
         package_verify_command => "/bin/rpm -V";
 
@@ -2023,6 +2032,7 @@ body package_method generic
         package_list_update_command => "/usr/bin/aptitude update";
         package_delete_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes remove";
         package_update_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes install";
+        package_patch_command =>  "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/aptitude -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --assume-yes install";
         package_verify_command => "/usr/bin/aptitude show";
         package_noverify_regex => "(State: not installed|E: Unable to locate package .*)";
 
@@ -2031,6 +2041,7 @@ body package_method generic
         package_list_update_command => "/usr/bin/apt-get update";
         package_delete_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes remove";
         package_update_command => "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes install";
+        package_patch_command =>  "/usr/bin/env DEBIAN_FRONTEND=noninteractive LC_ALL=C /usr/bin/apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --yes install";
         package_verify_command => "/usr/bin/dpkg -s";
         package_noverify_returncode => "1";
 
@@ -2060,6 +2071,7 @@ body package_method generic
         package_add_command => "/usr/bin/emerge -q --quiet-build";
         package_delete_command => "/usr/bin/emerge --depclean";
         package_update_command => "/usr/bin/emerge --update";
+        package_patch_command => "/usr/bin/emerge --update";
         package_verify_command => "/usr/bin/emerge -s";
         package_noverify_regex => ".*(Not Installed|Applications found : 0).*";
 }


### PR DESCRIPTION
Fixes #4070 - Add 'package_patch_command' attributes in initial promises

See http://www.rudder-project.org/redmine/issues/4070
