### PR TITLE
Fixes #4127: Add the check_rsyslog_version bundle to the bundlesequence ...

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -54,6 +54,7 @@ bundle common va
         "check_cf_processes",
         "check_uuid",
         "check_log_system",
+        "check_rsyslog_version",
         "check_cron_daemon",
         "garbage_collection",
         "check_binaries_freshness",
@@ -74,6 +75,7 @@ bundle common va
         "garbage_collection",
         "check_binaries_freshness",
         "check_log_system",
+        "check_rsyslog_version",
         "e2s_enable",
         "check_uuid"
       };


### PR DESCRIPTION
...to fix rSyslog rate limiting

Ticket: http://www.rudder-project.org/redmine/issues/4127

To be merged in 2.6 onwards !
