### PR TITLE
Fixes #4241: add carriage returns in the list of nodes for cf-serverd

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -108,25 +108,31 @@ body server control
         trustkeysfrom     => {
           "127.0.0.0/8" , "::1",
           @{def.acl} ,
-          &ALLOWCONNECT: { host2ip("&it&"), "&it&", }&
+          &ALLOWCONNECT: {
+          host2ip("&it&"), "&it&", }&
           &if(CLIENTSLIST)&
-          &MANAGED_NODES_NAME: { host2ip("&it&"), "&it&"};separator=", "&
+          &MANAGED_NODES_NAME: {
+          host2ip("&it&"), "&it&"};separator=", "&
           &endif&
         }; #trustkey allows the exchange of keys
 
         allowconnects     => {
           @{def.acl} ,
-          &ALLOWCONNECT: { host2ip("&it&"), "&it&", }&
+          &ALLOWCONNECT: {
+          host2ip("&it&"), "&it&", }&
           &if(CLIENTSLIST)&
-          &MANAGED_NODES_NAME: { host2ip("&it&"), "&it&"};separator=", "&
+          &MANAGED_NODES_NAME: {
+          host2ip("&it&"), "&it&"};separator=", "&
           &endif&
         };
 
         allowallconnects  => {
           @{def.acl} ,
-          &ALLOWCONNECT: { host2ip("&it&"), "&it&", }&
+          &ALLOWCONNECT: {
+          host2ip("&it&"), "&it&", }&
           &if(CLIENTSLIST)&
-          &MANAGED_NODES_NAME: { host2ip("&it&"), "&it&"};separator=", "&
+          &MANAGED_NODES_NAME: {
+          host2ip("&it&"), "&it&"};separator=", "&
           &endif&
         };
 
@@ -154,7 +160,8 @@ body server control
 body runagent control
 {
         hosts => {
-          &CLIENTSLIST: { "&it&",}&
+          &CLIENTSLIST: {
+          "&it&",}&
         };
 
         max_children => "25";


### PR DESCRIPTION
Now the generated code will look like this
{
        trustkeysfrom     => {
          "127.0.0.0/8" , "::1",
          @{def.acl} ,

```
                host2ip("xxxxxxx.labo.normation.com"), "xxxxxxx.labo.normation.com", 
                host2ip("xxxxxxx.labo.normation.com"), "xxxxxxx.labo.normation.com", 
```
