### PR TITLE
Fixes #4227: A Xen Hypervisor on SLES does not make a valid inventory an...

### DIFF
--- a/initial-promises/node-server/inventory/1.0/fusionAgent.cf
+++ b/initial-promises/node-server/inventory/1.0/fusionAgent.cf
@@ -106,7 +106,16 @@ bundle common inventory {
 }
 
 bundle agent fusionAgent {
-     
+
+  vars:
+    SuSE.xen_dom0::
+      "xen_tools_package" string => "xen-tools";
+    SuSE.xen_domu_pv::
+      "xen_tools_package" string => "xen-tools-domU";
+    debian::
+      "xen_tools_package" string => "xenstore-utils";
+    (redhat|centos)::
+      "xen_tools_package" string => "xen";
 
 	files:
 	linux|cygwin::
@@ -127,16 +136,9 @@ bundle agent fusionAgent {
 	    "${g.rudder_var_reports}\."
 		create => "true";
 
-        packages:
-            xen.(redhat|centos|SuSE)::
-            "xen"
-                package_policy => "add",
-                package_method => generic,
-                classes => cf2_if_else("xen_installed", "cant_install_xen"),
-                comment => "Installing xen package for extended data";
-
-            xen.debian::
-            "xenstore-utils"
+  packages:
+    xen::
+      "${xen_tools_package}"
                 package_policy => "add",
                 package_method => generic,
                 classes => cf2_if_else("xen_installed", "cant_install_xen"),
@@ -327,11 +329,11 @@ bundle agent addInformationsToInventory {
 
 		"users" slist => { readstringlist("${inventory.UserListFile}","#.*","[\n| |\r]",10,4000) };
 
-        xen.SuSE::
-                "VMRUDDERUUID" string => execresult("/bin/xenstore-read vm","noshell");
+    xen.SuSE.xen_domu_pv::
+      "VMRUDDERUUID" string => execresult("/bin/xenstore-read vm","noshell");
 
-        xen.(centos|redhat)::
-                "VMRUDDERUUID" string => execresult("/usr/bin/xenstore-read vm","noshell");
+    xen.(centos|redhat|(SuSE.xen_dom0))::
+      "VMRUDDERUUID" string => execresult("/usr/bin/xenstore-read vm","noshell");
 
         xen.(!SuSE.!centos.!redhat)::
                 "VMRUDDERUUID" string => execresult("/usr/sbin/xenstore-read vm","noshell");

--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -122,7 +122,16 @@ bundle common inventory {
 }
 
 bundle agent fusionAgent {
-     
+
+  vars:
+    SuSE.xen_dom0::
+      "xen_tools_package" string => "xen-tools";
+    SuSE.xen_domu_pv::
+      "xen_tools_package" string => "xen-tools-domU";
+    debian::
+      "xen_tools_package" string => "xenstore-utils";
+    (redhat|centos)::
+      "xen_tools_package" string => "xen";
 
 	files:
 	linux|cygwin::
@@ -145,16 +154,9 @@ bundle agent fusionAgent {
 		create => "true";
 &endif&
 
-        packages:
-            xen.(redhat|centos|SuSE)::
-            "xen"
-                package_policy => "add",
-                package_method => generic,
-                classes => cf2_if_else("xen_installed", "cant_install_xen"),
-                comment => "Installing xen package for extended data";
-
-            xen.debian::
-            "xenstore-utils"
+  packages:
+    xen::
+      "${xen_tools_package}"
                 package_policy => "add",
                 package_method => generic,
                 classes => cf2_if_else("xen_installed", "cant_install_xen"),
@@ -356,10 +358,10 @@ bundle agent addInformationsToInventory {
 		"users" slist => { readstringlist("${inventory.UserListFile}","#.*","[\n| |\r]",10,4000) };
 
 
-    xen.SuSE::
+    xen.SuSE.xen_domu_pv::
       "VMRUDDERUUID_cmd" string => "/bin/xenstore-read vm";
 
-    xen.(centos|redhat)::
+    xen.(centos|redhat|(SuSE.xen_dom0))::
       "VMRUDDERUUID_cmd" string => "/usr/bin/xenstore-read vm";
 
     xen.(!SuSE.!centos.!redhat)::


### PR DESCRIPTION
...d can't be accepted into Rudder since binary path to xenstore is wrong on SLES 11 and does not exist on SLES 10

See http://www.rudder-project.org/redmine/issues/4227
