### PR TITLE
Refs #4328: correct typo introduced by a37c059efe465de1dcb76451068f3fbfd...

### DIFF
--- a/techniques/systemSettings/remoteAccess/sshConfiguration/3.0/main.st
+++ b/techniques/systemSettings/remoteAccess/sshConfiguration/3.0/main.st
@@ -111,7 +111,7 @@ bundle agent rudder_openssh_server_configuration_reporting(class_prefix, service
 {
   methods:
       # Port edition defined
-      "any" usebundle => rudder_common_reports_generic("${service_name}", "${class_prefix}_ports", "${${params}[report]}", "SSH port configuration", "None", "The ${service_name} port configuration")
+      "any" usebundle => rudder_common_reports_generic("${service_name}", "${class_prefix}_ports", "${${params}[report]}", "SSH port configuration", "None", "The ${service_name} port configuration"),
         ifvarclass => "${class_prefix}_ports_edit";
       # When no port edition is defined
       "any" 


### PR DESCRIPTION
...d86495b (missing comma)
