### PR TITLE
Fixes #4375: add location of shared-folder in techniques

### DIFF
--- a/techniques/fileDistribution/copyGitFile/1.1/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/1.1/metadata.xml
@@ -46,7 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INPUT>
         <NAME>COPYFILE_NAME</NAME>
         <DESCRIPTION>Path of the file to be copied</DESCRIPTION>
-    <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server</LONGDESCRIPTION>
+        <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server.
+The default location of the shared folder is /var/rudder/configuration-repository/shared-files, but it can be overriden by changing the value of rudder.dir.shared.files.folder in the Rudder configuration file.</LONGDESCRIPTION>
       </INPUT>
       <INPUT>
         <NAME>COPYFILE_DESTINATION</NAME>

--- a/techniques/fileDistribution/copyGitFile/1.2/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/1.2/metadata.xml
@@ -46,7 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INPUT>
         <NAME>COPYFILE_NAME</NAME>
         <DESCRIPTION>Path of the file to be copied</DESCRIPTION>
-    <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server</LONGDESCRIPTION>
+        <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server.
+The default location of the shared folder is /var/rudder/configuration-repository/shared-files, but it can be overriden by changing the value of rudder.dir.shared.files.folder in the Rudder configuration file.</LONGDESCRIPTION>
       </INPUT>
       <INPUT>
         <NAME>COPYFILE_DESTINATION</NAME>

--- a/techniques/fileDistribution/copyGitFile/1.3/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/1.3/metadata.xml
@@ -47,7 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INPUT>
         <NAME>COPYFILE_NAME</NAME>
         <DESCRIPTION>Path of the file to be copied</DESCRIPTION>
-      <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server</LONGDESCRIPTION>
+        <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server.
+The default location of the shared folder is /var/rudder/configuration-repository/shared-files, but it can be overriden by changing the value of rudder.dir.shared.files.folder in the Rudder configuration file.</LONGDESCRIPTION>
       </INPUT>
       <INPUT>
         <NAME>COPYFILE_DESTINATION</NAME>

--- a/techniques/fileDistribution/copyGitFile/1.4/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/1.4/metadata.xml
@@ -47,7 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INPUT>
         <NAME>COPYFILE_NAME</NAME>
         <DESCRIPTION>Path of the file to be copied</DESCRIPTION>
-      <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server</LONGDESCRIPTION>
+        <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server.
+The default location of the shared folder is /var/rudder/configuration-repository/shared-files, but it can be overriden by changing the value of rudder.dir.shared.files.folder in the Rudder configuration file.</LONGDESCRIPTION>
       </INPUT>
       <INPUT>
         <NAME>COPYFILE_DESTINATION</NAME>

--- a/techniques/fileDistribution/copyGitFile/1.5/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/1.5/metadata.xml
@@ -47,7 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INPUT>
         <NAME>COPYFILE_NAME</NAME>
         <DESCRIPTION>Path of the file to be copied</DESCRIPTION>
-      <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server</LONGDESCRIPTION>
+        <LONGDESCRIPTION>This is the relative path of the file/folder to be copied, on the Rudder policy server.
+The default location of the shared folder is /var/rudder/configuration-repository/shared-files, but it can be overriden by changing the value of rudder.dir.shared.files.folder in the Rudder configuration file.</LONGDESCRIPTION>
       </INPUT>
           <SECTION name="Exclusion/Inclusion" multivalued="false" component="false" displayPriority="low">
             <SELECT1>


### PR DESCRIPTION
I put the info within the tooltip as it is more easily available when needed (the description are not easily available anymore in 2.9)
