### PR TITLE
Fixes #4384 - Fix wrong copy of ncf files wich included perserved wrong owner,group and permissions

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -46,11 +46,11 @@ bundle server access_rules
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 
-      "${g.rudder_ncf_origin_common}"
+      "${g.rudder_ncf}/common"
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 
-      "${g.rudder_ncf_origin_local}"
+      "${g.rudder_ncf}/local"
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -126,29 +126,31 @@ bundle agent update_action
 
     root_server::
       "${g.rudder_ncf}/common"
-        copy_from    => copy_digest("${g.rudder_ncf_origin_common}"),
+        copy_from    => copy_digesti_without_perms("${g.rudder_ncf_origin_common}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("544", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
         comment      => "Update the common Rudder ncf instance";
 
       "${g.rudder_ncf}/local"
-        copy_from    => copy_digest("${g.rudder_ncf_origin_local}"),
+        copy_from    => copy_digest_without_perms("${g.rudder_ncf_origin_local}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("544", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
         comment      => "Update the local Rudder ncf instance";
 
     !root_server::
       "${g.rudder_ncf}/common"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf_origin_common}"),
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf}/common"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action       => immediate,
         classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
         comment      => "Update the common Rudder ncf instance";
 
       "${g.rudder_ncf}/local"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf_origin_local}"),
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf}/local"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action       => immediate,
         classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
@@ -316,3 +318,18 @@ body service_method u_bootstart
         service_autostart_policy => "boot_time";
 }
 &endif&
+
+body copy_from copy_digest(from)
+{
+        source      => "${from}";
+        copy_backup => "false";
+        preserve    => "true";
+        compare     => "digest";
+}
+
+body perms u_mog(mode,user,group)
+{
+owners => { "$(user)" };
+groups => { "$(group)" };
+mode   => "$(mode)";
+}


### PR DESCRIPTION
Fixes #4384 - Fix wrong copy of ncf files wich included perserved wrong owner,group and permissions

cf http://www.rudder-project.org/redmine/issues/4384
