### PR TITLE
Fixes #4384 - Fix wrong copy of ncf files wich included perserved wrong owner,group and permissions

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -46,11 +46,11 @@ bundle server access_rules
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 
-      "${g.rudder_ncf}/common"
+      "${g.rudder_ncf_origin_common}"
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 
-      "${g.rudder_ncf}/local"
+      "${g.rudder_ncf_origin_local}"
         maproot => {  @{def.acl}  },
         admit   => {  @{def.acl}  };
 

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -60,6 +60,24 @@ body copy_from remote_unsecured(server, path)
 
 }
 
+body copy_from remote_unsecured_without_perms(server, path)
+{
+
+        servers    => {
+          "${server}"
+        };
+        encrypt    => "false";
+        trustkey   => "true";
+        source     => "${path}";
+        compare    => "mtime";
+        preserve   => "false"; #preserver permissions
+        verify     => "true";
+        purge      => "true";
+    community_edition::
+        portnumber => "&COMMUNITYPORT&";
+
+}
+
 bundle common server_info
 {
   vars:
@@ -126,9 +144,9 @@ bundle agent update_action
 
     root_server::
       "${g.rudder_ncf}/common"
-        copy_from    => copy_digesti_without_perms("${g.rudder_ncf_origin_common}"),
+        copy_from    => copy_digest_without_perms("${g.rudder_ncf_origin_common}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
-        perms        => u_mog("544", "root", "root"),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
         comment      => "Update the common Rudder ncf instance";
@@ -136,22 +154,24 @@ bundle agent update_action
       "${g.rudder_ncf}/local"
         copy_from    => copy_digest_without_perms("${g.rudder_ncf_origin_local}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
-        perms        => u_mog("544", "root", "root"),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
         comment      => "Update the local Rudder ncf instance";
 
     !root_server::
       "${g.rudder_ncf}/common"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf}/common"),
+        copy_from    => remote_unsecured_without_perms("${server_info.cfserved}", "${g.rudder_ncf_origin_common}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
         comment      => "Update the common Rudder ncf instance";
 
       "${g.rudder_ncf}/local"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf}/local"),
+        copy_from    => remote_unsecured_without_perms("${server_info.cfserved}", "${g.rudder_ncf_origin_local}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
         comment      => "Update the local Rudder ncf instance";
@@ -318,14 +338,6 @@ body service_method u_bootstart
         service_autostart_policy => "boot_time";
 }
 &endif&
-
-body copy_from copy_digest(from)
-{
-        source      => "${from}";
-        copy_backup => "false";
-        preserve    => "true";
-        compare     => "digest";
-}
 
 body perms u_mog(mode,user,group)
 {


### PR DESCRIPTION
Fixes #4384 - Fix wrong copy of ncf files wich included perserved wrong owner,group and permissions

cf http://www.rudder-project.org/redmine/issues/4384
