### PR TITLE
Fixes #4465 - Fix typo in metadata.xml

### DIFF
--- a/techniques/system/common/1.0/metadata.xml
+++ b/techniques/system/common/1.0/metadata.xml
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <OUTPATH>rudder_promises_generated</OUTPATH>
       <INCLUDED>false</INCLUDED>
     </TML>
-    <TML name="check_zypper">
+    <TML name="check_zypper"/>
   </TMLS>
 
   <SYSTEMVARS>


### PR DESCRIPTION
Fixes #4465 - Fix typo in metadata.xml

cf http://www.rudder-project.org/redmine/issues/4465
