### PR TITLE
fix typo

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -93,7 +93,7 @@ bundle common va
 # definition of the machine roles
   classes:
         # Policy Server is a machine which delivers promises
-      "policy_server" expression => strcmp("root","${uuid)");
+      "policy_server" expression => strcmp("root","${uuid}");
         # Root Server is the top policy server machine
       "root_server" expression => strcmp("root","${uuid}");
 }


### PR DESCRIPTION
Latest version of cfengine show error messages (and may be slower with
this mistake)
