### PR TITLE
Fixes #4128 - Rename option of ZMD 'package source policy' into 'security-level'

### DIFF
--- a/techniques/applications/zmdPackageManagerSettings/1.0/metadata.xml
+++ b/techniques/applications/zmdPackageManagerSettings/1.0/metadata.xml
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <SECTION name="General settings" component="true">
       <SELECT1>
         <NAME>ZMD_SOURCEPOLICY</NAME>
-        <DESCRIPTION>Package sources policy</DESCRIPTION>
+        <DESCRIPTION>Security level</DESCRIPTION>
         <LONGDESCRIPTION>This option defines which component of a repository is used as a trusted reference for the packages. Signature checks the package against the repository PGP key and Checksum only checks the package integrity. None installs the packages blindly without checking them.</LONGDESCRIPTION>
         <ITEM>
           <VALUE>signature</VALUE>


### PR DESCRIPTION
Fixes #4128 - Rename option of ZMD 'package source policy' into 'security-level'

cf http://www.rudder-project.org/redmine/issues/4128
