### PR TITLE
Fixes #4281: disable RepeatedMsgReduction in rudder rsyslog conf

### DIFF
--- a/initial-promises/node-server/distributePolicy/rsyslog.conf/rudder.conf
+++ b/initial-promises/node-server/distributePolicy/rsyslog.conf/rudder.conf
@@ -18,6 +18,9 @@
 
 # Rsyslog Rudder configuration
 
+# Disable Repeated message reduction or reports may be lost
+$RepeatedMsgReduction off
+
 # Provides TCP syslog reception
 $ModLoad imtcp
 $InputTCPServerRun ${install_rsyslogd.rsyslog_port[2]}

--- a/techniques/system/distributePolicy/1.0/rudder.st
+++ b/techniques/system/distributePolicy/1.0/rudder.st
@@ -18,6 +18,9 @@
 
 # Rsyslog Rudder configuration
 
+# Disable Repeated message reduction or reports may be lost
+$RepeatedMsgReduction off
+
 # Provides TCP syslog reception
 $ModLoad imtcp
 $InputTCPServerRun &SYSLOGPORT&


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/4281

We can disable Directive repeatedMsgReduction here, it will not impact configuration in /etc/rsyslog.conf and will disable it for rudder related message

See: http://stackoverflow.com/questions/20542758/rsyslog-conditional-repeatedmsgreduction
