### PR TITLE
Fixes #4533: A freshly installed rudder-root-server won't do anything po...

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -93,9 +93,9 @@ bundle common va
 # definition of the machine roles
   classes:
         # Policy Server is a machine which delivers promises
-      "policy_server" expression => strcmp("root","${uuid)");
+        "policy_server" expression => strcmp("root", "${rudder_roles.uuid)");
         # Root Server is the top policy server machine
-      "root_server" expression => strcmp("root","${uuid}");
+        "root_server"   expression => strcmp("root", "${rudder_roles.uuid}");
 }
 
 #########################################################


### PR DESCRIPTION
...licy-server specific (import inventories, update configs...) until the web interface regenerates promises
