### PR TITLE
Fixes #4555: Missing body in update.cf in system techniques (introduced ...

### DIFF
--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -60,6 +60,14 @@ body copy_from remote_unsecured(server, path)
 
 }
 
+body copy_from copy_digest_without_perms(from)
+{
+        source      => "${from}";
+        copy_backup => "false";
+        preserve    => "false";
+        compare     => "digest";
+}
+
 body copy_from remote_unsecured_without_perms(server, path)
 {
 
@@ -70,7 +78,7 @@ body copy_from remote_unsecured_without_perms(server, path)
         trustkey   => "true";
         source     => "${path}";
         compare    => "mtime";
-        preserve   => "false"; #preserver permissions
+        preserve   => "false";
         verify     => "true";
         purge      => "true";
     community_edition::


### PR DESCRIPTION
...by fix for #4384 - enforce permissions on ncf file copies)

See http://www.rudder-project.org/redmine/issues/4555
