### PR TITLE
filter rudder_dependencies on classes.

### DIFF
--- a/initial-promises/node-server/common/1.0/site.cf
+++ b/initial-promises/node-server/common/1.0/site.cf
@@ -36,6 +36,21 @@ bundle common g
       "rudder_inventories"  string => "${rudder_var}\inventories";
       "rudder_base_sbin_arg" string => "${sys.winprogdir}\Rudder\sbin"; # for the installer command line
       "rudder_dependencies" string => "${rudder_sbin}";
+      "rudder_dep_files_windows" slist => { "uuid.vbs",
+					    "iconv.dll",
+					    "userlist.bat",
+					    "getDate.bat",
+					    "registrydns.bat",
+					    "iconv.exe",
+					    "curl/curl.exe",
+					    "curl/libcurl.dll",
+					    "curl/libssl32.dll",
+					    "curl/libeay32.dll",
+					    "cpuid-windows-v1.0.vbs",
+					    "fusionagent.exe",
+					    "centreon-e2s.exe",
+					    "e2s.tpl",
+					    "checkroute.pl" };
       "escaped_workdir" string => escape("${sys.workdir}");
       "rudder_curl" string => "${rudder_base_sbin}\curl\curl.exe";
 
@@ -73,6 +88,7 @@ bundle common g
       "rudder_inventories" string  => "${rudder_var}/inventories";
       "uuid_file" string => "${rudder_base}/etc/uuid.hive";
       "rudder_dependencies" string => "${rudder_var}/tools";
+      "rudder_dep_files_android" slist => { "cpuid-android-V1.0.sh" };
       "crontab" string => "/etc/crontab";
       "rudder_curl" string => "/system/bin/curl";
       "rudder_rm" string => "/system/xbin/rm";
@@ -80,6 +96,18 @@ bundle common g
       # The time at which the execution started
       "execRun" string => execresult("/system/xbin/date \"+%Y-%m-%d %T%z\" | sed 's/\([-+][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'", "useshell");
 
+   linux::
+      "rudder_dep_files_linux" slist => { "send-clean.sh",
+					  "cpuid-linux-V1.0.sh",
+					  "vmware_info.sh",
+					  "check_rsyslog_version",
+					  "apache-vhost.tpl" };
+
+    SuSE::
+      "rudder_dep_files_suse" slist => { "openvpn-2.2.1-1.x86_64.rpm",
+					 "openvpn-2.2.1-1.i686.rpm",
+					 "zypper-repo.tpl",
+					 "checkzmd.pl" };
     any::
       "uuid" string => readfile("${g.uuid_file}", 60);
       "server_shares_folder" string  => "/var/rudder/share/${uuid}/promises/shares";
@@ -88,5 +116,9 @@ bundle common g
       "davpw" string => "rudder";
       "excludedreps" slist => { "\.X11", ".*kde.*", "\.svn", "perl" };
       "rudder_dependencies_origin" string => "/var/rudder/tools";
-
+      "rudder_dependencies_files" slist => { @{rudder_dep_files_windows},
+					     @{rudder_dep_files_android},
+					     @{rudder_dep_files_linux},
+					     @{rudder_dep_files_suse},
+					   }, policy => "ifdefined";
 }

--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -107,16 +107,16 @@ bundle agent update
         ifvarclass => "(config|config_ok).!no_update";
 
     rudder_promises_generated_repaired.!root_server.(!windows|cygwin)::
-      "${g.rudder_dependencies}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}"),
+      "${g.rudder_dependencies}/${g.rudder_dependencies_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}/${g.rudder_dependencies_files}"),
       #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action => immediate,
         classes => success("rudder_dependencies_updated", "rudder_dependencies_update_error", "rudder_dependencies_updated_ok");
 
     rudder_promises_generated_repaired.!root_server.(windows.!cygwin)::
-      "${g.rudder_sbin}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}"),
+      "${g.rudder_sbin}//${g.rudder_dependencies_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}/${g.rudder_dependencies_files}"),
       #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action => immediate,

--- a/techniques/system/common/1.0/site.st
+++ b/techniques/system/common/1.0/site.st
@@ -36,6 +36,21 @@ bundle common g
       "rudder_inventories"         string => "${rudder_var}\inventories";
       "rudder_base_sbin_arg"       string => "${sys.winprogdir}\Rudder\sbin"; # for the installer command line
       "rudder_dependencies"        string => "${rudder_sbin}";
+      "rudder_dep_files_windows"   slist => { "uuid.vbs",
+					      "iconv.dll",
+					      "userlist.bat",
+					      "getDate.bat",
+					      "registrydns.bat",
+					      "iconv.exe",
+					      "curl/curl.exe",
+					      "curl/libcurl.dll",
+					      "curl/libssl32.dll",
+					      "curl/libeay32.dll",
+					      "cpuid-windows-v1.0.vbs",
+					      "fusionagent.exe",
+					      "centreon-e2s.exe",
+					      "e2s.tpl",
+					      "checkroute.pl" };
       "escaped_workdir"            string => escape("${sys.workdir}");
       "rudder_curl"                string => "${rudder_base_sbin}\curl\curl.exe";
       # The time at which the execution started
@@ -71,6 +86,7 @@ bundle common g
       "rudder_inventories"         string => "${rudder_var}/inventories";
       "uuid_file"                  string => "${rudder_base}/etc/uuid.hive";
       "rudder_dependencies"        string => "${rudder_var}/tools";
+      "rudder_dep_files_android"   slist => { "cpuid-android-V1.0.sh" };
       "crontab"                    string => "/etc/crontab";
       "rudder_curl"                string => "/system/bin/curl";
       "rudder_rm"                  string => "/system/xbin/rm";
@@ -78,6 +94,18 @@ bundle common g
       # The time at which the execution started
       "execRun"                    string => execresult("/system/xbin/date \"+%Y-%m-%d %T%z\" | sed 's/\([-+][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'", "useshell");
 
+   linux::
+      "rudder_dep_files_linux"      slist => { "send-clean.sh",
+					       "cpuid-linux-V1.0.sh",
+					       "vmware_info.sh",
+					       "check_rsyslog_version",
+					       "apache-vhost.tpl",
+					       "checkroute.pl" };
+   SuSE::
+     "rudder_dep_files_suse"       slist => { "openvpn-2.2.1-1.x86_64.rpm",
+					      "openvpn-2.2.1-1.i686.rpm",
+					      "zypper-repo.tpl",
+					      "checkzmd.pl" };
 
    any::
      "uuid"                        string => readfile("$(g.uuid_file)", 60);
@@ -87,7 +115,11 @@ bundle common g
      "davpw"                       string => "&DAVPASSWORD&";
      "excludedreps"                slist => { "\.X11", ".*kde.*", "\.svn", "perl" };
      "rudder_dependencies_origin"  string => "/var/rudder/tools";
+     "rudder_dependencies_files"   slist => { @{rudder_dep_files_windows},
+					      @{rudder_dep_files_android},
+					      @{rudder_dep_files_linux},
+					      @{rudder_dep_files_suse},
+					    }, policy => "ifdefined";
      # The time at which the execution started
      "execRun"                     string => execresult("${execRun_cmd}", "noshell");
-
 }

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -140,16 +140,16 @@ bundle agent update_action
 
     # same here, if the dependencies have been updated, we can skup this part 
     rudder_promises_generated_repaired.(!windows|cygwin).!rudder_dependencies_updated.!rudder_dependencies_updated_ok::
-      "${g.rudder_dependencies}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}"),
+      "${g.rudder_dependencies}/${g.rudder_dependencies_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}/${g.rudder_dependencies_files}"),
         #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action       => immediate,
         classes      => success("rudder_dependencies_updated", "rudder_dependencies_update_error", "rudder_dependencies_updated_ok");
 
     rudder_promises_generated_repaired.(windows.!cygwin).!rudder_dependencies_updated.!rudder_dependencies_updated_ok::
-      "${g.rudder_sbin}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}"),
+      "${g.rudder_sbin}//${g.rudder_dependencies_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_dependencies_origin}/${g.rudder_dependencies_files}"),
         #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action       => immediate,


### PR DESCRIPTION
Until now every files in rudder_dependencies are copied, for example
.exe files are copied on linux node.
This can be a problem for low bandwith / low disk space devices.
This patch create a list for each platform in order to copy only useful
classes.
