### PR TITLE
Fixes #4652:  Change the default TTL for CFEngine outputs files from 30 ...

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -426,7 +426,7 @@ bundle agent garbage_collection
       "${sys.workdir}/outputs"
 
         delete => tidy,
-        file_select => days_old("30"),
+        file_select => days_old("7"),
         depth_search => recurse("inf");
 
       "${g.rudder_var}/modified-files"


### PR DESCRIPTION
...days to 7 days in initial promises
