### PR TITLE
Fixes #4700: cf-agent fails on systems that don't support "find . -not ....

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -93,7 +93,7 @@ bundle common va
     any::
       "end" slist => { "endExecution" };
 
-      "ncf_inputs" slist => splitstring(execresult("/usr/bin/find /var/rudder/ncf -name '*.cf' -not -name 'promises.cf'", "noshell"), "\n", 10000);
+      "ncf_inputs" slist => splitstring(execresult("/usr/bin/find /var/rudder/ncf -name '*.cf' ! -name 'promises.cf'", "noshell"), "\n", 10000);
 
 
 # definition of the machine roles


### PR DESCRIPTION
....." (AIX, in particular)
