### PR TITLE
Fix #4590: filter rudder_tools on classes.

### DIFF
--- a/initial-promises/node-server/common/1.0/site.cf
+++ b/initial-promises/node-server/common/1.0/site.cf
@@ -31,6 +31,7 @@ bundle common g
       "rudder_var"                 string => "/data/rudder";
       "rudder_curl"                string => "/system/bin/curl";
       "rudder_rm"                  string => "/system/xbin/rm";
+      "rudder_tools_files_android" slist => { "cpuid-android-V1.0.sh" };
 
     !windows.!android::
       "rudder_base"                string => "/opt/rudder";
@@ -72,6 +73,23 @@ bundle common g
       "escaped_workdir"            string => escape("${sys.workdir}");
       "rudder_curl"                string => "${rudder_base_sbin}\curl\curl.exe";
 
+      "rudder_tools_files_windows" slist => { "uuid.vbs",
+                                              "iconv.dll",
+                                              "userlist.bat",
+                                              "getDate.bat",
+                                              "registrydns.bat",
+                                              "iconv.exe",
+                                              "curl/curl.exe",
+                                              "curl/libcurl.dll",
+                                              "curl/libssl32.dll",
+                                              "curl/libeay32.dll",
+                                              "cpuid-windows-v1.0.vbs",
+                                              "fusionagent.exe",
+                                              "centreon-e2s.exe",
+                                              "e2s.tpl",
+                                              "checkroute.pl" };
+
+
       # DEPRECATED: This variable is used in pre-2.9 Techniques.
       "rudder_dependencies"        string => "${rudder_sbin}";
 
@@ -107,6 +125,25 @@ bundle common g
       "execRun" string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
     !linux.!cygwin.!windows.!android.!aix::
       "execRun" string => execresult("/bin/date \"+%Y-%m-%d %T%:z\"", "noshell");
+
+    linux::
+      "rudder_tools_files_linux"   slist => { "send-clean.sh",
+                                              "cpuid-linux-V1.0.sh",
+                                              "vmware_info.sh",
+                                              "check_rsyslog_version",
+                                              "apache-vhost.tpl" };
+    SuSE::
+      "rudder_tools_files_suse"    slist => { "openvpn-2.2.1-1.x86_64.rpm",
+                                              "openvpn-2.2.1-1.i686.rpm",
+                                              "zypper-repo.tpl",
+                                              "check_zypper_version",
+                                              "checkzmd.pl" };
+    any::
+      "rudder_tools_files"         slist => { @{rudder_tools_files_windows},
+                                              @{rudder_tools_files_android},
+                                              @{rudder_tools_files_linux},
+                                              @{rudder_tools_files_suse},
+                                            }, policy => "ifdefined";
 
   classes:
 

--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -127,16 +127,16 @@ bundle agent update
         touch      => "true";
 
     rudder_promises_generated_repaired.!root_server.(!windows|cygwin)::
-      "${g.rudder_tools}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}"),
+      "${g.rudder_tools}/${g.rudder_tools_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}/${g.rudder_tools_files}"),
       #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action => immediate,
         classes => success("rudder_tools_updated", "rudder_tools_update_error", "rudder_tools_updated_ok");
 
     rudder_promises_generated_repaired.!root_server.(windows.!cygwin)::
-      "${g.rudder_sbin}"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}"),
+      "${g.rudder_sbin}/${g.rudder_tools_files}"
+        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}/${g.rudder_tools_files}"),
       #depth_search => recurse("inf"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
         action => immediate,

--- a/techniques/system/common/1.0/site.st
+++ b/techniques/system/common/1.0/site.st
@@ -31,6 +31,7 @@ bundle common g
       "rudder_var"                 string => "/data/rudder";
       "rudder_curl"                string => "/system/bin/curl";
       "rudder_rm"                  string => "/system/xbin/rm";
+      "rudder_tools_files_android" slist => { "cpuid-android-V1.0.sh" };
 
     !windows.!android::
       "rudder_base"                string => "/opt/rudder";
@@ -73,6 +74,22 @@ bundle common g
       "rudder_curl"                string => "\"${rudder_base_sbin}\curl\curl.exe\"";
       "uuid_file"                  string => "${rudder_base}\etc\uuid.hive";
       "rudder_disable_agent_file"  string => "${rudder_base}\etc\disable-agent";
+      "rudder_tools_files_windows" slist => { "uuid.vbs",
+                                              "iconv.dll",
+                                              "userlist.bat",
+                                              "getDate.bat",
+                                              "registrydns.bat",
+                                              "iconv.exe",
+                                              "curl/curl.exe",
+                                              "curl/libcurl.dll",
+                                              "curl/libssl32.dll",
+                                              "curl/libeay32.dll",
+                                              "cpuid-windows-v1.0.vbs",
+                                              "fusionagent.exe",
+                                              "centreon-e2s.exe",
+                                              "e2s.tpl",
+                                              "checkroute.pl" };
+
 
       # DEPRECATED: This variable is used in pre-2.9 Techniques.
       "rudder_dependencies"        string => "${rudder_sbin}";
@@ -105,6 +122,24 @@ bundle common g
     !linux.!cygwin.!windows.!android.!aix::
       "execRun"                    string => execresult("/bin/date \"+%Y-%m-%d %T%:z\"", "noshell");
 
+    linux::
+      "rudder_tools_files_linux"   slist => { "send-clean.sh",
+                                              "cpuid-linux-V1.0.sh",
+                                              "vmware_info.sh",
+                                              "check_rsyslog_version",
+                                              "apache-vhost.tpl" };
+    SuSE::
+      "rudder_tools_files_suse"    slist => { "openvpn-2.2.1-1.x86_64.rpm",
+                                              "openvpn-2.2.1-1.i686.rpm",
+                                              "zypper-repo.tpl",
+                                              "check_zypper_version",
+                                              "checkzmd.pl" };
+    any::
+      "rudder_tools_files"         slist => { @{rudder_tools_files_windows},
+                                              @{rudder_tools_files_android},
+                                              @{rudder_tools_files_linux},
+                                              @{rudder_tools_files_suse},
+                                            }, policy => "ifdefined";
   classes:
 
     "curl_installed"           expression => isexecutable("${rudder_curl}");


### PR DESCRIPTION
Until now every files in rudder_tools are copied, for example
.exe files are copied on linux node.
This can be a problem for low bandwith / low disk space devices.
This patch create a list for each platform in order to copy only useful
classes.
