### PR TITLE
Fixes #4745: cfengine 3.6 complains about a typo.

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -93,7 +93,7 @@ bundle common va
 # definition of the machine roles
   classes:
         # Policy Server is a machine which delivers promises
-        "policy_server" expression => strcmp("root", "${rudder_roles.uuid)");
+        "policy_server" expression => strcmp("root", "${rudder_roles.uuid}");
         # Root Server is the top policy server machine
         "root_server"   expression => strcmp("root", "${rudder_roles.uuid}");
 }


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/4745
