### PR TITLE
Fix #4749: skipidentify and mobile devices

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -31,9 +31,9 @@ body common control
 }
 
 body agent control {
-    # we can not depend on DNS for mobile devices
-    android::
-      skipidentify=> "true";
+   # we can not depend on DNS for mobile devices or NATed device
+    any::
+        skipidentify => "true";
 }
 
 bundle common g

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -34,9 +34,7 @@ body common control
 }
 
 body agent control {
-   # we can not depend on DNS for mobile devices
-   android::
-      skipidentify=> "true";
+        skipidentify => "&SKIPIDENTIFY&";
 }
 
 bundle common g


### PR DESCRIPTION
do not treat mobile devices differently.
