### PR TITLE
Fixes #4780: Replace uses of CLIENTSLIST by equivalent MANAGED_NODES_NAME

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -24,7 +24,7 @@
 
 bundle server access_rules
 {
-&if(CLIENTSLIST)&
+&if(MANAGED_NODES_NAME)&
   # Access rules are only defined on a policy server. Standard nodes should not share any files.
   access:
 
@@ -192,11 +192,11 @@ body server control
 
 #######################################################
 
-&if(CLIENTSLIST)&
+&if(MANAGED_NODES_NAME)&
 body runagent control
 {
         hosts => {
-          &CLIENTSLIST: {
+          &MANAGED_NODES_NAME: {
           "&it&",}&
         };
 

--- a/techniques/system/common/1.0/metadata.xml
+++ b/techniques/system/common/1.0/metadata.xml
@@ -57,7 +57,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <SYSTEMVARS>
     <NAME>AUTHORIZED_NETWORKS</NAME>
-    <NAME>CLIENTSLIST</NAME>
     <NAME>INPUTLIST</NAME>
     <NAME>LICENSESPAID</NAME>
     <NAME>BUNDLELIST</NAME>


### PR DESCRIPTION
Both CLIENTSLIST and MANAGED_NODES_NAME contains the list of nodes' hostnames managed by a policy server. MANAGED_NODES_NAME is better named and is more used, so remove the other one. 
