### PR TITLE
Fixes #4758 - Add PATH to ensure binaries are always usables

### DIFF
--- a/tools/check_rsyslog_version
+++ b/tools/check_rsyslog_version
@@ -1,6 +1,9 @@
 #!/bin/bash
 #set -e
 
+# Add PATH to ensure that binaries will always be found
+PATH=${PATH}:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
 TARGET_VER='5.7.1'
 LOCAL_VER=`rsyslogd -v | head -n1 | sed "s/^rsyslogd \([^, ]*\).*$/\1/"`
 


### PR DESCRIPTION
Fixes #4758 - Add PATH to ensure binaries are always usables

cf http://www.rudder-project.org/redmine/issues/4758
