### PR TITLE
Fixes #4869 - Uncomment 'set -e' to permit to stop at encountered error

### DIFF
--- a/tools/check_rsyslog_version
+++ b/tools/check_rsyslog_version
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e
+set -e
 
 TARGET_VER='5.7.1'
 LOCAL_VER=`rsyslogd -v | head -n1 | sed "s/^rsyslogd \([^, ]*\).*$/\1/"`


### PR DESCRIPTION
Fixes #4869 - Uncomment 'set -e' to permit to stop at encountered error

cf http://www.rudder-project.org/redmine/issues/4869
