### PR TITLE
Fixes #3855 - Add specific package_methods rudder_yum to manage RPM on RHEL with less requests to RHN and use them on Techniques 'System', 'Inventory' and 'NTP'

### DIFF
--- a/techniques/system/common/1.0/rudder_lib.st
+++ b/techniques/system/common/1.0/rudder_lib.st
@@ -462,6 +462,34 @@ body package_method rudder_rug
         package_verify_command        => "/usr/bin/rug verify -y$"; # $ means no args
 }
 
+########################################################################
+# Install a package using yum but with a check from rpm                #
+########################################################################
+body package_method rudder_yum
+{
+
+ package_changes => "bulk";
+ package_list_command => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+ package_list_name_regex    => "^(\S+?)\s\S+?\s\S+$";
+ package_list_version_regex => "^\S+?\s(\S+?)\s\S+$";
+ package_list_arch_regex    => "^\S+?\s\S+?\s(\S+)$";
+ package_installed_regex => ".*";
+ package_name_convention => "$(name)";
+ package_list_update_command => "/usr/bin/yum --quiet check-update";
+ package_list_update_ifelapsed => "240";
+ package_patch_installed_regex => "^\s.*";
+ package_patch_name_regex    => "([^.]+).*";
+ package_patch_version_regex => "[^\s]\s+([^\s]+).*";
+ package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
+ package_add_command    => "/usr/bin/yum -y install";
+ package_update_command => "/usr/bin/yum -y update";
+ package_patch_command => "/usr/bin/yum -y update";
+ package_delete_command => "/bin/rpm -e --nodeps --allmatches";
+ package_verify_command => "/bin/rpm -V";
+
+}
+
+
 ###################################################
 # edit_line prepend
 ###################################################

--- a/techniques/system/distributePolicy/1.0/rsyslogConf.st
+++ b/techniques/system/distributePolicy/1.0/rsyslogConf.st
@@ -77,7 +77,7 @@ bundle agent install_rsyslogd {
                                 classes => cf2_if_else("rsyslog_pgsql_installed", "cant_install_rsyslog_pgsql"),
                                 comment => "Installing rsyslog_pgsql using apt backports";
 
-                policy_server.!debian_5.!SuSE::
+                policy_server.!debian_5.!SuSE.!redhat::
                         "rsyslog"
                                 package_policy  => "add",
                                 package_method  => generic,
@@ -87,6 +87,19 @@ bundle agent install_rsyslogd {
                         "rsyslog-pgsql"
                                 package_policy  => "add",
                                 package_method  => generic,
+                                classes => cf2_if_else("rsyslog_pgsql_installed", "cant_install_rsyslog_pgsql"),
+                                comment => "Installing rsyslog_pgsql using apt backports";
+
+                policy_server.!debian_5.!SuSE.redhat::
+                        "rsyslog"
+                                package_policy  => "add",
+                                package_method  => rudder_yum,
+                                classes => cf2_if_else("rsyslog_installed", "cant_install_rsyslog"),
+                                comment => "Installing rsyslog using apt backports";
+
+                        "rsyslog-pgsql"
+                                package_policy  => "add",
+                                package_method  => rudder_yum,
                                 classes => cf2_if_else("rsyslog_pgsql_installed", "cant_install_rsyslog_pgsql"),
                                 comment => "Installing rsyslog_pgsql using apt backports";
 

--- a/techniques/system/inventory/1.0/fetchFusionTools.st
+++ b/techniques/system/inventory/1.0/fetchFusionTools.st
@@ -34,7 +34,7 @@ bundle agent fetchFusionTools
     redhat::
       "curl"
         package_policy  => "add",
-        package_method  => yum,
+        package_method  => rudder_yum,
         classes => rudder_common_classes("fetchFusionTools_install_curl"),
         comment => "Installing curl using yum";
 

--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -163,10 +163,17 @@ bundle agent fusionAgent
 &endif&
 
   packages:
-    xen::
+    xen.!redhat::
       "${xen_tools_package}"
         package_policy => "add",
         package_method => generic,
+        classes        => cf2_if_else("xen_installed", "cant_install_xen"),
+        comment        => "Installing xen package for extended data";
+
+    xen.redhat::
+      "${xen_tools_package}"
+        package_policy => "add",
+        package_method => rudder_yum,
         classes        => cf2_if_else("xen_installed", "cant_install_xen"),
         comment        => "Installing xen package for extended data";
 

--- a/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
@@ -159,7 +159,7 @@ bundle agent check_clock_configuration
 
   # Install the NTP package
   packages:
-    debian::
+    debian.!redhat::
       "ntp"
         package_policy  => "add",
         package_method  => apt,
@@ -168,8 +168,8 @@ bundle agent check_clock_configuration
 
     redhat::
       "ntp"
-        package_policy => "add",
-        package_method => generic,
+        package_policy  => "add",
+        package_method  => rudder_yum,
         classes => kept_if_else("ntp_install_kept", "ntp_installed", "cant_install_ntp"),
         comment => "Installing ntp using yum";
 


### PR DESCRIPTION
Fixes #3855 - Add specific package_methods rudder_yum to manage RPM on RHEL with less requests to RHN and use them on Techniques 'System', 'Inventory' and 'NTP'

cf http://www.rudder-project.org/redmine/issues/3855
