### PR TITLE
Fixes #4894 - Synchronize update.{st,cf} between Techniques and initial-promises

### DIFF
--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -60,22 +60,78 @@ body copy_from remote_unsecured(server, path)
 
 }
 
+body copy_from copy_digest_without_perms(from)
+{
+        source      => "${from}";
+        copy_backup => "false";
+        preserve    => "false";
+        compare     => "digest";
+        purge       => "true";
+}
+
+body copy_from remote_unsecured_without_perms(server, path)
+{
+
+        servers    => {
+          "${server}"
+        };
+        encrypt    => "false";
+        trustkey   => "true";
+        source     => "${path}";
+        compare    => "mtime";
+        preserve   => "false";
+        verify     => "true";
+        purge      => "true";
+        portnumber => "5309";
+
+}
+
 bundle common server_info
 {
   vars:
     any::
-      "policy_files" string  => "/var/rudder/share/${g.uuid}";   #directory where to look for promises in the server for that client
+      "policy_files"  string  => "/var/rudder/share/${g.uuid}";   #directory where to look for promises in the server for that client
 
     policy_server::
       "cfserved" string => "%%POLICY_SERVER_HOSTNAME%%";
 
     !policy_server::
-      "policy_server_file" string  => translatepath("${sys.workdir}/policy_server.dat"),
+      "policy_server_file"
+        string  => translatepath("${sys.workdir}/policy_server.dat"),
         comment => "Path to file containing address to policy server";
       "cfserved" string =>  readfile("${policy_server_file}", 40);            #server IP
 }
 
+# The update is now split in two parts
+# - the action part, only launched during failsafe
+#   it copies files, restarts deamons, defines persistent classes
+# - the report part, not done during failsafe but during regular run
+#   note that if in verbose_mode, then the reporting will be done
+#   as well during failsafe
+#
+# Since the defined class are persistent, the classes are still
+# available during the "normal" agent execution, for reporting
 bundle agent update
+{
+  methods:
+    failsafe::
+      "update" usebundle => update_action;
+    (!failsafe|verbose_mode)::
+      "report" usebundle => update_reports;
+
+  reports:
+    # We want to have always reports if something goes bad
+    rudder_promises_generated_error|no_update::
+      "*********************************************************************************
+* rudder-agent could not get an updated configuration from the policy server.   *
+* This can be caused by a network issue, an unavailable server, or if this      *
+* node was deleted from the Rudder root server.                                 *
+* Any existing configuration policy will continue to be applied without change. *
+*********************************************************************************"
+      action => immediate;
+}
+
+bundle agent update_action
 {
   vars:
       "client_inputs"        string => "${sys.workdir}/inputs";  #where to put the files on the client when downloaded
@@ -93,26 +149,47 @@ bundle agent update
         create  => "true",
         comment => "Make sure the ncf directory exists";
 
+    root_server::
       "${g.rudder_ncf}/common"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf_origin_common}"),
+        copy_from    => copy_digest_without_perms("${g.rudder_ncf_origin_common}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
         comment      => "Update the common Rudder ncf instance";
 
       "${g.rudder_ncf}/local"
-        copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_ncf_origin_local}"),
+        copy_from    => copy_digest_without_perms("${g.rudder_ncf_origin_local}"),
         depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
         action       => immediate,
         classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
         comment      => "Update the local Rudder ncf instance";
 
     !root_server::
+      "${g.rudder_ncf}/common"
+        copy_from    => remote_unsecured_without_perms("${server_info.cfserved}", "${g.rudder_ncf_origin_common}"),
+        depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
+        action       => immediate,
+        classes      => success("rudder_ncf_common_updated", "rudder_ncf_common_update_error", "rudder_ncf_common_updated_ok"),
+        comment      => "Update the common Rudder ncf instance";
+
+      "${g.rudder_ncf}/local"
+        copy_from    => remote_unsecured_without_perms("${server_info.cfserved}", "${g.rudder_ncf_origin_local}"),
+        depth_search => recurse_ignore("inf", @{g.excludedreps}),
+        perms        => u_mog("644", "root", "root"),
+        action       => immediate,
+        classes      => success("rudder_ncf_local_updated", "rudder_ncf_local_update_error", "rudder_ncf_local_updated_ok"),
+        comment      => "Update the local Rudder ncf instance";
+
       "${client_inputs}/${file_to_check_update}"
         copy_from    => remote("${server_info.cfserved}","${server_inputs}/${file_to_check_update}"),
         action       => immediate,
         classes      => success("rudder_promises_generated_repaired", "rudder_promises_generated_error", "rudder_promises_generated_ok");
 
+    # The defined class are persistent, so if they are already set, promises has already been updated
+    # a short while ago
     rudder_promises_generated_repaired.!root_server::
       "${client_inputs}"
         copy_from    => remote("${server_info.cfserved}","${server_inputs}"),
@@ -126,6 +203,7 @@ bundle agent update
       "${sys.workdir}/last_successful_inputs_update"
         touch      => "true";
 
+    # same here, if the tools have been updated, we can skip this part
     rudder_promises_generated_repaired.!root_server.(!windows|cygwin)::
       "${g.rudder_tools}"
         copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}"),
@@ -168,6 +246,18 @@ bundle agent update
 #########################################################
   reports:
     server_ok::
+      "@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Started the server (cf-serverd)";
+    executor_ok::
+      "@@Common@@log_repaired@@&TRACKINGKEY&@@Update@@None@@${g.execRun}##${g.uuid}@#Started the scheduler (cf-execd)";
+}
+
+# This bundle is responsible for the reporting of what happened in the update
+# It can work because the classes defined during the update are persistent, so
+# the classes are available for the next 4 minutes
+bundle agent update_reports
+{
+  reports:
+    server_ok::
       "@@Common@@log_repaired@@hasPolicyServer-root@@common-root@@00@@Update@@None@@${g.execRun}##${g.uuid}@#Started the server (cf-serverd)";
     executor_ok::
       "@@Common@@log_repaired@@hasPolicyServer-root@@common-root@@00@@Update@@None@@${g.execRun}##${g.uuid}@#Started the scheduler (cf-execd)";
@@ -205,13 +295,6 @@ bundle agent update
     rudder_promises_generated_repaired|config|rudder_tools_updated|rudder_ncf_common_updated|rudder_ncf_local_updated|server_ok|executor_ok::
       "@@Common@@result_repaired@@hasPolicyServer-root@@common-root@@00@@Update@@None@@${g.execRun}##${g.uuid}@#Policy or dependencies were updated or CFEngine service restarted";
 
-
-    rudder_promises_generated_error|no_update::
-        "*********************************************************************************
-* rudder-agent could not get an updated configuration from the policy server.   *
-* This can be caused by a network issue, an unavailable server, or if this      *
-* node has not yet been accepted in the Rudder root server.                     *
-*********************************************************************************";
 }
 
 
@@ -233,6 +316,10 @@ body classes success(if, else, kept)
         repair_failed => { "${else}" };
         repair_denied => { "${else}" };
         repair_timeout => { "${else}" };
+
+        # persist for 4 minutes so that it wont overlap with the next
+        # execution in 5 minutes
+        persist_time     => "4";
 }
 
 ############################################
@@ -240,4 +327,11 @@ body action u_ifwin_bg
 {
     windows::
         background => "true";
+}
+
+body perms u_mog(mode,user,group)
+{
+owners => { "$(user)" };
+groups => { "$(group)" };
+mode   => "$(mode)";
 }


### PR DESCRIPTION
Fixes #4894 - Synchronize update.{st,cf} between Techniques and initial-promises

cf http://www.rudder-project.org/redmine/issues/4894
