### PR TITLE
Fixes #4963: RHEL 3 and 4 don't report correctly due to "/bin/date: unre...

### DIFF
--- a/techniques/system/common/1.0/site.st
+++ b/techniques/system/common/1.0/site.st
@@ -57,7 +57,8 @@ bundle common g
       "crontab"                    string => "/etc/crontab";
 
     # The time at which the execution started
-    "execRun_cmd" string => "/bin/date --rfc-3339=second";
+    # We would like to use date's "--rfc-3339=second" option here, but it is not available on older OSes (RHEL 3/4, AIX 5...)
+    "execRun_cmd"                  string => "/bin/date -u \"+%Y-%m-%d %T+00:00\"";
 
    any::
      "uuid"                        string => readfile("$(g.uuid_file)", 60);


### PR DESCRIPTION
...cognized option --rfc-3339=second"
