### PR TITLE
Fixes #4963: RHEL 3 and 4 don't report correctly due to "/bin/date: unre...

### DIFF
--- a/initial-promises/node-server/common/1.0/site.cf
+++ b/initial-promises/node-server/common/1.0/site.cf
@@ -57,8 +57,12 @@ bundle common g
       "crontab" string => "/etc/crontab";
 
     # The time at which the execution started
+    (linux|cygwin).!(centos_3|redhat_3|centos_4|redhat_4)::
       "execRun" string => execresult("/bin/date --rfc-3339=second", "noshell");
 
+    (linux|cygwin).(centos_3|redhat_3|centos_4|redhat_4)::
+      # We would like to use date's "--rfc-3339=second" option here, but it is not available on older OSes (RHEL 3/4, AIX 5...)
+      "execRun" string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
 
     any::
       "uuid" string => readfile("${g.uuid_file}", 60);

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -58,7 +58,12 @@ bundle common g
       "rudder_sbin"                string => "${rudder_base}/sbin";
       "rudder_base_sbin"           string => "${rudder_base}/sbin"; #folder where tools are installed
       "rudder_dependencies"        string => "/var/rudder/tools";
+
+    # The time at which the execution started
+    (linux|cygwin).!(centos_3|redhat_3|centos_4|redhat_4)::
       "execRun"                    string => execresult("/bin/date --rfc-3339=second", "noshell");
+    (linux|cygwin).(centos_3|redhat_3|centos_4|redhat_4)::
+      "execRun"                    string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
 
 
 # definition of the node roles

--- a/techniques/system/common/1.0/site.st
+++ b/techniques/system/common/1.0/site.st
@@ -57,7 +57,11 @@ bundle common g
       "crontab"                    string => "/etc/crontab";
 
     # The time at which the execution started
-    "execRun_cmd" string => "/bin/date --rfc-3339=second";
+    (linux|cygwin).!(centos_3|redhat_3|centos_4|redhat_4)::
+      "execRun_cmd"                string => "/bin/date --rfc-3339=second";
+    (linux|cygwin).(centos_3|redhat_3|centos_4|redhat_4)::
+      # We would like to use date's "--rfc-3339=second" option here, but it is not available on older OSes (RHEL 3/4, AIX 5...)
+      "execRun_cmd"                string => "/bin/date -u \"+%Y-%m-%d %T+00:00\"";
 
    any::
      "uuid"                        string => readfile("$(g.uuid_file)", 60);


### PR DESCRIPTION
...cognized option --rfc-3339=second"
