### PR TITLE
Bug 4966/failsafe cf in initial promises doesn t have a execdate variable causing all reports to not contain the date time

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -51,6 +51,12 @@ bundle common g
       "rudder_dependencies" string => "/var/rudder/tools";
       "uuid_file" string => "${rudder_base}/etc/uuid.hive";
 
+    # The time at which the execution started
+    (linux|cygwin).!(centos_3|redhat_3|centos_4|redhat_4)::
+      "execRun"                    string => execresult("/bin/date --rfc-3339=second", "noshell");
+    (linux|cygwin).(centos_3|redhat_3|centos_4|redhat_4)::
+      "execRun"                    string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
+
     any::
       "uuid" string => readfile("${g.uuid_file}", 60);
       "excludedreps" slist => { "\.X11", ".*kde.*", "\.svn", "perl" };


### PR DESCRIPTION
See http://www.rudder-project.org/redmine/issues/4966
