### PR TITLE
Fixes #4974: AIX and unsupported OSes: failsafe.cf in initial-promises d...

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -79,6 +79,11 @@ bundle common g
       "execRun"                  string => execresult("\"${g.rudder_sbin}\getDate.bat\"", "noshell");
     android::
       "execRun"                  string => execresult("/system/xbin/date \"+%Y-%m-%d %T+02:00\"", "noshell");
+    aix::
+      # AIX's date command doesn't have a "%z" option, so we fake it by using UTC
+      "execRun"                  string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
+    !linux.!cygwin.!windows.!android.!aix::
+      "execRun"                  string => execresult("/bin/date \"+%Y-%m-%d %T%:z\"", "noshell");
 
     any::
       "uuid"                     string => readfile("${g.uuid_file}", 60);


### PR DESCRIPTION
...oesn't have a "execDate" variable, causing all reports to not contain the date/time
