### PR TITLE
Fixes #4969: Remove skipverify from the Techniques, as this attribute is...

### DIFF
--- a/initial-promises/node-server/common/1.0/cf-served.cf
+++ b/initial-promises/node-server/common/1.0/cf-served.cf
@@ -105,8 +105,6 @@ body server control
         cfruncommand      => "${sys.workdir}/bin/cf-agent -f failsafe.cf && ${sys.workdir}/bin/cf-agent";
         allowusers        => { "root" };
 
-        skipverify            => { "127.0.0.0/8" , "::1",  @{def.acl}  };
-
     community_edition::
         port => "5309";
 

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/common/cf-served.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/common/cf-served.cf
@@ -101,8 +101,6 @@ body server control
         cfruncommand      => "${sys.workdir}/bin/cf-agent -f failsafe.cf && ${sys.workdir}/bin/cf-agent";
         allowusers        => { "root" };
 
-        skipverify            => { "127.0.0.0/8" , "::1",  @{def.acl}  };
-
     community_edition::
         port => "5309";
 

--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -183,8 +183,6 @@ body server control
 
         denybadclocks => "&DENYBADCLOCKS&";
 
-        skipverify        => { "127.0.0.0/8" , "::1",  @{def.acl}  };
-
     community_edition::
         port => "&COMMUNITYPORT&";
 


### PR DESCRIPTION
... deprecated in CFEngine 3.6

Ticket: http://www.rudder-project.org/redmine/issues/4969

To be merged in 2.11
