### PR TITLE
Fixes #4992: add the class failsafe in failsafe.cf to allow nodes to bootstrap again

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -99,6 +99,9 @@ bundle common rudder_roles
       "policy_server" expression => strcmp("root","${g.uuid}");
         # Root Server is the top policy server machine
       "root_server" expression => strcmp("root","${g.uuid}");
+
+       # We are in the failsafe phase
+      "failsafe" expression => "any";
 }
 
 ############################################


### PR DESCRIPTION
This is a very high priority bug: anyone installing Rudder right now CANNOT fetch its promises from the policy server !
