### PR TITLE
Fixes #5003: initial promises on server cause an error to be logged due ...

### DIFF
--- a/initial-promises/node-server/distributePolicy/1.0/rsyslogConf.cf
+++ b/initial-promises/node-server/distributePolicy/1.0/rsyslogConf.cf
@@ -109,9 +109,8 @@ bundle agent install_rsyslogd
     policy_server::
       "/etc/rsyslog.d/rudder.conf"
         create    => "true",
-        edit_defaults => empty,
         edit_line => expand_template("${sys.workdir}/inputs/distributePolicy/rsyslog.conf/rudder.conf"),
-        edit_defaults => noempty_backup,
+        edit_defaults => empty_backup,
         classes => cf2_if_else("rudder_rsyslog_conf_copied", "cannot_copy_rudder_rsyslog_conf"),
         comment => "Copying rsyslog conf";
 


### PR DESCRIPTION
...to duplicate "empty_file_before_editing" setting
