### PR TITLE
Fixes #5237: Use localhost has a rSyslog postgresql target when rudder-s...

### DIFF
--- a/initial-promises/node-server/distributePolicy/1.0/rsyslogConf.cf
+++ b/initial-promises/node-server/distributePolicy/1.0/rsyslogConf.cf
@@ -28,13 +28,15 @@ bundle agent install_rsyslogd
     rsyslog_port_not_found::
       "rsyslog_port[2]"    string => "514";
 
-    root_server|role_rudder_relay_top::
-      # Define the where to send the syslog messages
-      # default is localhost if the rudder_db is unknown
-      "rudder_postgres_server" string => "localhost",
-        ifvarclass => "!role_rudder_db_server_defined";
-      "rudder_postgres_server" string => "${rudder_servers_by_role.roles[rudder-db]}",
-        ifvarclass => "role_rudder_db_server_defined";
+    # Define the where to send the syslog messages
+    # default is localhost if the rudder_db is unknown
+    # or if the role rudder-server-root is installed
+
+    root_server.(!role_rudder_db_server_defined|role_rudder_server_root)::
+      "rudder_postgres_server" string => "localhost";
+
+    (root_server|role_rudder_relay_top).role_rudder_db_server_defined.!role_rudder_server_root::
+      "rudder_postgres_server" string => "${rudder_servers_by_role.roles[rudder-db]}";
 
   classes:
     # There is no "equals" function for ints in CFEngine (currently, at least) so we compare strings

--- a/techniques/system/distributePolicy/1.0/rsyslogConf.st
+++ b/techniques/system/distributePolicy/1.0/rsyslogConf.st
@@ -19,20 +19,24 @@
 # Configure rsyslog on the root/relay servers
 
 bundle agent install_rsyslogd {
-	vars:
 
-		root_server|role_rudder_relay_top::
-			"rsyslog_source_file" string => "rudder-rsyslog-root.conf";
+  vars:
 
-      # Define the where to send the syslog messages
-      # default is localhost if the rudder_db is unknown
-      "rudder_postgres_server" string => "localhost",
-        ifvarclass => "!role_rudder_db_server_defined";
-      "rudder_postgres_server" string => "${rudder_servers_by_role.roles[rudder-db]}",
-        ifvarclass => "role_rudder_db_server_defined";
+    root_server|role_rudder_relay_top::
+      "rsyslog_source_file" string => "rudder-rsyslog-root.conf";
 
-		policy_server.!(root_server|role_rudder_relay_top)::
-			"rsyslog_source_file" string => "rudder-rsyslog-relay.conf";
+    # Define the where to send the syslog messages
+    # default is localhost if the rudder_db is unknown
+    # or if the role rudder-server-root is installed
+
+    root_server.(!role_rudder_db_server_defined|role_rudder_server_root)::
+      "rudder_postgres_server" string => "localhost";
+
+    (root_server|role_rudder_relay_top).role_rudder_db_server_defined.!role_rudder_server_root::
+      "rudder_postgres_server" string => "${rudder_servers_by_role.roles[rudder-db]}";
+
+    policy_server.!(root_server|role_rudder_relay_top)::
+      "rsyslog_source_file" string => "rudder-rsyslog-relay.conf";
 
 	packages:
 


### PR DESCRIPTION
...erver-root is installed

Ticket: http://www.rudder-project.org/redmine/issues/5237

To be merged in 2.11
