### PR TITLE
Fixes #5146 - Use localhost as default policy_server to prevent error messages without policy_server.dat file

### DIFF
--- a/initial-promises/node-server/common/1.0/cf-served.cf
+++ b/initial-promises/node-server/common/1.0/cf-served.cf
@@ -69,8 +69,17 @@ bundle common def
       "policy_server_file" string => translatepath("${sys.workdir}/policy_server.dat"),
         comment => "Path to file containing address to policy server";
 
-      "policy_server"      string => readfile("${policy_server_file}", 2048),
+   # Use localhost as default policy_server if no policy_server.dat exists
+    policy_server_set::
+      "policy_server"
+        string  => readfile("${policy_server_file}", 2048),
         comment => "IP address or hostname to locate your policy host.";
+    !policy_server_set::
+      "policy_server"
+        string  => "rudder",
+        comment => "IP address by default without ${def.policy_server_file} file";
+
+    any::
 
       "dir_masterfiles" string => translatepath("${sys.workdir}/masterfiles");
 
@@ -84,6 +93,10 @@ bundle common def
       "acl" slist => {
       "${def.policy_server}"
     };
+
+  classes:
+      "policy_server_set" expression => fileexists("${def.policy_server_file}");
+
 }
 
 

--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -95,7 +95,15 @@ bundle common server_info
       "policy_server_file"
         string  => translatepath("${sys.workdir}/policy_server.dat"),
         comment => "Path to file containing address to policy server";
-      "cfserved" string =>  readfile("${policy_server_file}", 2048);
+
+   # Use localhost as default policy_server if no policy_server.dat exists
+    policy_server_set::
+      "cfserved" string => readfile("${policy_server_file}", 2048);
+    !policy_server_set::
+      "cfserved" string => "rudder";
+
+  classes:
+      "policy_server_set" expression => fileexists("${server_info.policy_server_file}");
 }
 
 # The update is now split in two parts

--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -94,9 +94,17 @@ bundle common def
         string  => translatepath("${sys.workdir}/policy_server.dat"),
         comment => "Path to file containing address to policy server";
 
+   # Use localhost as default policy_server if no policy_server.dat exists
+    policy_server_set::
       "policy_server"
         string  => readfile("${policy_server_file}", 2048),
         comment => "IP address or hostname to locate your policy host.";
+    !policy_server_set::
+      "policy_server"
+        string  => "rudder",
+        comment => "IP address by default without ${def.policy_server_file} file";
+
+    any::
 
       "dir_masterfiles" string => translatepath("${sys.workdir}/masterfiles");
 
@@ -114,6 +122,9 @@ bundle common def
       "acl" slist => {
       "${def.policy_server}"
     };
+
+  classes:
+      "policy_server_set" expression => fileexists("${def.policy_server_file}");
 }
 
 

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -96,7 +96,15 @@ bundle common server_info
       "policy_server_file"
         string  => translatepath("${sys.workdir}/policy_server.dat"),
         comment => "Path to file containing address to policy server";
-      "cfserved"     string =>  readfile("${policy_server_file}", 2048);
+
+   # Use localhost as default policy_server if no policy_server.dat exists
+    policy_server_set::
+      "cfserved" string => readfile("${policy_server_file}", 2048);
+    !policy_server_set::
+      "cfserved" string => "rudder";
+
+  classes:
+      "policy_server_set" expression => fileexists("${server_info.policy_server_file}");
 }
 
 # The update is now split in two parts


### PR DESCRIPTION
Fixes #5146 - Use localhost as default policy_server to prevent error messages without policy_server.dat file

cf http://www.rudder-project.org/redmine/issues/5146
