### PR TITLE
Fixes #5459: Update tools even if promises were not repaired

### DIFF
--- a/initial-promises/node-server/common/1.0/update.cf
+++ b/initial-promises/node-server/common/1.0/update.cf
@@ -225,7 +225,7 @@ bundle agent update_action
         touch      => "true";
 
     # same here, if the tools have been updated, we can skip this part
-    rudder_promises_generated_repaired.!root_server.(!windows|cygwin)::
+    !root_server.(!windows|cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
       "${g.rudder_tools}/${g.rudder_tools_files}"
         copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}/${g.rudder_tools_files}"),
       #depth_search => recurse("inf"),
@@ -233,7 +233,7 @@ bundle agent update_action
         action => immediate,
         classes => success("rudder_tools_updated", "rudder_tools_update_error", "rudder_tools_updated_ok");
 
-    rudder_promises_generated_repaired.!root_server.(windows.!cygwin)::
+    !root_server.(windows.!cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
       "${g.rudder_sbin}/${g.rudder_tools_files}"
         copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}/${g.rudder_tools_files}"),
       #depth_search => recurse("inf"),

--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -226,7 +226,7 @@ bundle agent update_action
         touch      => "true";
 
     # same here, if the tools have been updated, we can skip this part
-    rudder_promises_generated_repaired.(!windows|cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
+    !root_server.(!windows|cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
       "${g.rudder_tools}"
         copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}"),
         #depth_search => recurse("inf"),
@@ -235,7 +235,7 @@ bundle agent update_action
         classes      => success("rudder_tools_updated", "rudder_tools_update_error", "rudder_tools_updated_ok"),
         comment      => "Update the Rudder tools";
 
-    rudder_promises_generated_repaired.(windows.!cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
+    !root_server.(windows.!cygwin).!rudder_tools_updated.!rudder_tools_updated_ok::
       "${g.rudder_sbin}"
         copy_from    => remote_unsecured("${server_info.cfserved}", "${g.rudder_tools_origin}"),
         #depth_search => recurse("inf"),


### PR DESCRIPTION
We want to update tools more often, than just when promises were generated
