### PR TITLE
Fixes #5595: Use rpmvercmp or dpkg to do version comparison when needed

### DIFF
--- a/initial-promises/node-server/common/1.0/rudder_lib.cf
+++ b/initial-promises/node-server/common/1.0/rudder_lib.cf
@@ -22,6 +22,42 @@
 #
 #####################################################################################
 
+###################################################
+# Knowledge from the original stdlib
+###################################################
+# Uses a specific prefix to avoid collision
+# when the stdlib will be updated
+###################################################
+
+bundle common rudder_debian_knowledge
+# @depends paths
+# @brief common Rudder Debian knowledge bundle
+#
+# This common bundle has useful information about Debian.
+{
+  vars:
+
+      "dpkg_compare_equal" string => "/usr/bin/dpkg --compare-versions '${v1}' eq '${v2}'";
+      "dpkg_compare_less"  string => "/usr/bin/dpkg --compare-versions '${v1}' lt '${v2}'";
+
+}
+
+
+bundle common rudder_rpm_knowledge
+# @depends paths
+# @brief common Rudder RPM knowledge bundle
+#
+# This common bundle has useful information about platforms using RPM
+{
+  vars:
+
+      "rpm_compare_equal" string => "${sys.workdir}/bin/rpmvercmp '${v1}' eq '${v2}'";
+      "rpm_compare_less"  string => "${sys.workdir}/bin/rpmvercmp '${v1}' lt '${v2}'";
+
+}
+
+###################################################
+
 body depth_search recurse_visible(d)
 {
         depth        => "${d}";
@@ -115,17 +151,19 @@ body location append
 #########################################################
 body package_method yum_remi
 {
-        package_changes => "bulk";
-        package_list_command => "/usr/bin/yum list installed";
-        package_list_name_regex    => "([^.]+).*";
-        package_list_version_regex => "[^\s]\s+([^\s]+).*";
-        package_list_arch_regex    => "[^.]+\.([^\s]+).*";
-        package_installed_regex => ".*installed.*";
-        package_name_convention => "${name}.${arch}";
-        package_delete_convention  => "${name}";
-        package_add_command => "/usr/bin/yum --enablerepo=remi -y install";
-        package_delete_command => "/bin/rpm -e";
-        package_verify_command => "/bin/rpm -V";
+
+        package_changes               => "bulk";
+        package_list_command          => "/usr/bin/yum list installed";
+        package_list_name_regex       => "([^.]+).*";
+        package_list_version_regex    => "[^\s]\s+([^\s]+).*";
+        package_list_arch_regex       => "[^.]+\.([^\s]+).*";
+        package_installed_regex       => ".*installed.*";
+        package_name_convention       => "${name}.${arch}";
+        package_delete_convention     => "${name}";
+        package_add_command           => "/usr/bin/yum --enablerepo=remi -y install";
+        package_delete_command        => "/bin/rpm -e";
+        package_verify_command        => "/bin/rpm -V";
+
 }
 
 #perms validation
@@ -445,26 +483,31 @@ body package_method rudder_rug
 
         package_changes => "individual";
 
-        package_list_command => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
-        package_patch_list_command => "/usr/bin/rug patches";
+        package_list_command          => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
+        package_patch_list_command    => "/usr/bin/rug patches";
         package_list_update_ifelapsed => "240";
-        package_installed_regex => "i.*";
-        package_list_name_regex    => "[^|]+\|[^|]+\|\s+([^\s]+).*";
-        package_list_version_regex => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
-        package_list_arch_regex    => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+        package_installed_regex       => "i.*";
+        package_list_name_regex       => "[^|]+\|[^|]+\|\s+([^\s]+).*";
+        package_list_version_regex    => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+        package_list_arch_regex       => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
 
         package_patch_installed_regex => ".*Installed.*|.*Not Applicable.*";
-        package_patch_name_regex    => "[^|]+\|\s+([^\s]+).*";
-        package_patch_version_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
+        package_patch_name_regex      => "[^|]+\|\s+([^\s]+).*";
+        package_patch_version_regex   => "[^|]+\|[^|]+\|\s+([^\s]+).*";
 
-        package_name_convention => "${name}";
-        package_add_command => "/usr/bin/rug install -y";
-        package_delete_command => "/usr/bin/rug remove -y";
-        package_update_command => "/usr/bin/rug update -y";
+        package_name_convention       => "${name}";
+        package_add_command           => "/usr/bin/rug install -y";
+        package_delete_command        => "/usr/bin/rug remove -y";
+        package_update_command        => "/usr/bin/rug update -y";
 
-#Unsure about the behavior of this command ...
-#package_patch_command => "/usr/bin/rug patch-info";
-        package_verify_command => "/usr/bin/rug verify -y$"; # $ means no args
+        #Unsure about the behavior of this command ...
+        #package_patch_command        => "/usr/bin/rug patch-info";
+        package_verify_command        => "/usr/bin/rug verify -y$"; # $ means no args
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 ########################################################################
@@ -473,23 +516,27 @@ body package_method rudder_rug
 body package_method rudder_yum
 {
 
- package_changes => "bulk";
- package_list_command => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
- package_list_name_regex    => "^(\S+?)\s\S+?\s\S+$";
- package_list_version_regex => "^\S+?\s(\S+?)\s\S+$";
- package_list_arch_regex    => "^\S+?\s\S+?\s(\S+)$";
- package_installed_regex => ".*";
- package_name_convention => "$(name)";
- package_list_update_command => "/usr/bin/yum --quiet check-update";
- package_list_update_ifelapsed => "240";
- package_patch_name_regex    => "([^.]+).*";
- package_patch_version_regex => "[^\s]\s+([^\s]+).*";
- package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
- package_add_command    => "/usr/bin/yum -y install";
- package_update_command => "/usr/bin/yum -y update";
- package_patch_command => "/usr/bin/yum -y update";
- package_delete_command => "/bin/rpm -e --nodeps --allmatches";
- package_verify_command => "/bin/rpm -V";
+        package_changes               => "bulk";
+        package_list_command          => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+        package_list_name_regex       => "^(\S+?)\s\S+?\s\S+$";
+        package_list_version_regex    => "^\S+?\s(\S+?)\s\S+$";
+        package_list_arch_regex       => "^\S+?\s\S+?\s(\S+)$";
+        package_installed_regex       => ".*";
+        package_name_convention       => "$(name)";
+        package_list_update_command   => "/usr/bin/yum --quiet check-update";
+        package_list_update_ifelapsed => "240";
+        package_patch_name_regex      => "([^.]+).*";
+        package_patch_version_regex   => "[^\s]\s+([^\s]+).*";
+        package_patch_arch_regex      => "[^.]+\.([^\s]+).*";
+        package_add_command           => "/usr/bin/yum -y install";
+        package_update_command        => "/usr/bin/yum -y update";
+        package_patch_command         => "/usr/bin/yum -y update";
+        package_delete_command        => "/bin/rpm -e --nodeps --allmatches";
+        package_verify_command        => "/bin/rpm -V";
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
 
 }
 

--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -450,7 +450,7 @@ bundle agent check_binaries_freshness
 
     community_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "rpmvercmp" };
 
     nova_edition::
 

--- a/techniques/applications/aptPackageInstallation/1.0/aptPackageInstallation.st
+++ b/techniques/applications/aptPackageInstallation/1.0/aptPackageInstallation.st
@@ -73,6 +73,12 @@ bundle agent check_apt_package_installation
 body package_method apt_nobulk(apt_pkg_timeout)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_debian_knowledge.dpkg_compare_less}";
+        package_version_equal_command => "${rudder_debian_knowledge.dpkg_compare_equal}";
+
     debian::
         package_changes => "individual";
         package_list_update_ifelapsed => "${apt_pkg_timeout}";

--- a/techniques/applications/aptPackageInstallation/1.1/aptPackageInstallation.st
+++ b/techniques/applications/aptPackageInstallation/1.1/aptPackageInstallation.st
@@ -92,6 +92,12 @@ bundle agent check_apt_package_installation
 body package_method apt_nobulk(apt_pkg_timeout)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_debian_knowledge.dpkg_compare_less}";
+        package_version_equal_command => "${rudder_debian_knowledge.dpkg_compare_equal}";
+
     debian::
         package_changes => "individual";
         package_list_update_ifelapsed => "${apt_pkg_timeout}";

--- a/techniques/applications/aptPackageInstallation/1.2/aptPackageInstallation.st
+++ b/techniques/applications/aptPackageInstallation/1.2/aptPackageInstallation.st
@@ -95,6 +95,12 @@ bundle agent check_apt_package_installation
 body package_method apt_nobulk(apt_pkg_timeout, allow_untrusted)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_debian_knowledge.dpkg_compare_less}";
+        package_version_equal_command => "${rudder_debian_knowledge.dpkg_compare_equal}";
+
     debian::
         package_changes => "individual";
         package_list_update_ifelapsed => "${apt_pkg_timeout}";

--- a/techniques/applications/aptPackageInstallation/2.0/aptPackageInstallation.st
+++ b/techniques/applications/aptPackageInstallation/2.0/aptPackageInstallation.st
@@ -95,6 +95,12 @@ bundle agent check_apt_package_installation
 body package_method apt_nobulk(apt_pkg_timeout, allow_untrusted)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_debian_knowledge.dpkg_compare_less}";
+        package_version_equal_command => "${rudder_debian_knowledge.dpkg_compare_equal}";
+
     debian::
         package_changes => "individual";
         package_list_update_ifelapsed => "${apt_pkg_timeout}";

--- a/techniques/applications/aptPackageInstallation/3.0/aptPackageInstallation.st
+++ b/techniques/applications/aptPackageInstallation/3.0/aptPackageInstallation.st
@@ -95,6 +95,12 @@ bundle agent check_apt_package_installation
 body package_method apt_nobulk(apt_pkg_timeout, allow_untrusted)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_debian_knowledge.dpkg_compare_less}";
+        package_version_equal_command => "${rudder_debian_knowledge.dpkg_compare_equal}";
+
     debian::
         package_changes => "individual";
         package_list_update_ifelapsed => "${apt_pkg_timeout}";

--- a/techniques/applications/rpmPackageInstallation/1.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/1.0/rpmPackageInstallation.st
@@ -90,6 +90,10 @@ body package_method yum_nobulk(rpm_pkg_timeout)
         package_delete_command => "/bin/rpm -e";
         package_verify_command => "/bin/rpm -V";
 
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body package_method zypper_nobulk(rpm_pkg_timeout)
@@ -108,6 +112,11 @@ body package_method zypper_nobulk(rpm_pkg_timeout)
         package_delete_command => "/usr/bin/zypper --non-interactive remove --force-resolution";
         package_update_command => "/usr/bin/zypper --non-interactive update";
         package_verify_command => "/usr/bin/zypper --non-interactive verify$";
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body classes class_trigger_rpm_retcodes(if,else,kept)

--- a/techniques/applications/rpmPackageInstallation/2.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/2.0/rpmPackageInstallation.st
@@ -98,6 +98,10 @@ body package_method yum_nobulk(rpm_pkg_timeout)
         package_delete_command => "/bin/rpm -e";
         package_verify_command => "/bin/rpm -V";
 
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body package_method zypper_nobulk(rpm_pkg_timeout)
@@ -116,6 +120,11 @@ body package_method zypper_nobulk(rpm_pkg_timeout)
         package_delete_command => "/usr/bin/zypper --non-interactive remove --force-resolution";
         package_update_command => "/usr/bin/zypper --non-interactive update";
         package_verify_command => "/usr/bin/zypper --non-interactive verify$";
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body package_method rug_nobulk(rpm_pkg_timeout)
@@ -136,6 +145,11 @@ body package_method rug_nobulk(rpm_pkg_timeout)
         package_update_command => "/usr/bin/rug update -y";
 
         package_verify_command => "/usr/bin/rug verify -y$"; # $ means no args
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body classes class_trigger_rpm_retcodes(if,else,kept)

--- a/techniques/applications/rpmPackageInstallation/2.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/2.1/rpmPackageInstallation.st
@@ -132,6 +132,10 @@ body package_method yum_nobulk(rpm_pkg_timeout)
         package_delete_command => "/bin/rpm -e";
         package_verify_command => "/bin/rpm -V";
 
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body package_method zypper_nobulk(rpm_pkg_timeout)
@@ -150,6 +154,11 @@ body package_method zypper_nobulk(rpm_pkg_timeout)
         package_delete_command => "/usr/bin/zypper --non-interactive remove --force-resolution";
         package_update_command => "/usr/bin/zypper --non-interactive update";
         package_verify_command => "/usr/bin/zypper --non-interactive verify$";
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body package_method rug_nobulk(rpm_pkg_timeout)
@@ -170,6 +179,11 @@ body package_method rug_nobulk(rpm_pkg_timeout)
         package_update_command => "/usr/bin/rug update -y";
 
         package_verify_command => "/usr/bin/rug verify -y$"; # $ means no args
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 body classes class_trigger_rpm_retcodes(if,else,kept)

--- a/techniques/applications/rpmPackageInstallation/2.2/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/2.2/rpmPackageInstallation.st
@@ -126,6 +126,12 @@ bundle agent check_rpm_package_installation
 body package_method generic_nobulk(rpm_pkg_timeout)
 {
 
+    any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
     redhat::
         package_changes => "individual";
 

--- a/techniques/applications/rpmPackageInstallation/3.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/3.0/rpmPackageInstallation.st
@@ -111,6 +111,13 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
+any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
+
 redhat::
 	package_changes => "individual";
 

--- a/techniques/applications/rpmPackageInstallation/4.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/4.0/rpmPackageInstallation.st
@@ -168,6 +168,13 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
+any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
+
 redhat::
 	package_changes => "individual";
 

--- a/techniques/applications/rpmPackageInstallation/4.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/4.1/rpmPackageInstallation.st
@@ -168,6 +168,12 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
+any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 redhat::
 	package_changes => "individual";
 

--- a/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
@@ -153,6 +153,12 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
+any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 	package_changes => "individual";
 
 redhat::

--- a/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
@@ -153,6 +153,12 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
+any::
+
+        # make correct version comparisons
+        package_version_less_command => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 	package_changes => "individual";
 
 redhat::

--- a/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
@@ -153,47 +153,57 @@ bundle agent check_rpm_package_installation {
 
 body package_method generic_nobulk(rpm_pkg_timeout) {
 
-	package_changes => "individual";
+    any::
 
-redhat::
-  package_list_command => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
 
-  package_list_name_regex    => "^(\S+?)\s\S+?\s\S+$";
-  package_list_version_regex => "^\S+?\s(\S+?)\s\S+$";
-  package_list_arch_regex    => "^\S+?\s\S+?\s(\S+)$";
+	package_changes               => "individual";
 
-	package_installed_regex => ".*";
-	package_name_convention => "${name}-${version}";
+    redhat::
+
+        package_list_command          => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+
+        package_list_name_regex       => "^(\S+?)\s\S+?\s\S+$";
+        package_list_version_regex    => "^\S+?\s(\S+?)\s\S+$";
+        package_list_arch_regex       => "^\S+?\s\S+?\s(\S+)$";
+
+	package_installed_regex       => ".*";
+	package_name_convention       => "${name}-${version}";
 	package_list_update_ifelapsed => "${rpm_pkg_timeout}";
-	package_add_command => "/usr/bin/yum -y install";
-	package_delete_command => "/bin/rpm -e";
-	package_verify_command => "/bin/rpm -V";
+	package_add_command           => "/usr/bin/yum -y install";
+	package_delete_command        => "/bin/rpm -e";
+	package_verify_command        => "/bin/rpm -V";
 
-zypper_version_ok::
-	package_list_command => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
+    zypper_version_ok::
+
+	package_list_command          => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
 	package_list_update_ifelapsed => "${rpm_pkg_timeout}";
-	package_installed_regex => "i.*";
-	package_list_name_regex => "[^|]+\|[^|]+\|\s+([^\s]+).*";
-	package_list_version_regex => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
-	package_list_arch_regex => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
-	package_name_convention => "${name}";
-	package_add_command => "/usr/bin/zypper --non-interactive install";
-	package_delete_command => "/usr/bin/zypper --non-interactive remove --force-resolution";
-	package_update_command => "/usr/bin/zypper --non-interactive update";
-	package_verify_command => "/usr/bin/zypper --non-interactive verify$";
+	package_installed_regex       => "i.*";
+	package_list_name_regex       => "[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_list_version_regex    => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_list_arch_regex       => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_name_convention       => "${name}";
+	package_add_command           => "/usr/bin/zypper --non-interactive install";
+	package_delete_command        => "/usr/bin/zypper --non-interactive remove --force-resolution";
+	package_update_command        => "/usr/bin/zypper --non-interactive update";
+	package_verify_command        => "/usr/bin/zypper --non-interactive verify$";
 
-SuSE_10.!zypper_version_ok::
-	package_list_command => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
+    SuSE_10.!zypper_version_ok::
+
+	package_list_command          => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
 	package_list_update_ifelapsed => "${rpm_pkg_timeout}";
-	package_installed_regex => "i.*";
-	package_list_name_regex    => "[^|]+\|[^|]+\|\s+([^\s]+).*";
-	package_list_version_regex => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
-	package_list_arch_regex    => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_installed_regex       => "i.*";
+	package_list_name_regex       => "[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_list_version_regex    => "[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
+	package_list_arch_regex       => "[^|]+\|[^|]+\|[^|]+\|[^|]+\|\s+([^\s]+).*";
 
-	package_name_convention => "${name}";
-	package_add_command => "/usr/bin/rug install -y";
-	package_delete_command => "/usr/bin/rug remove -y";
-	package_update_command => "/usr/bin/rug update -y";
+	package_name_convention       => "${name}";
+	package_add_command           => "/usr/bin/rug install -y";
+	package_delete_command        => "/usr/bin/rug remove -y";
+	package_update_command        => "/usr/bin/rug update -y";
 
-	package_verify_command => "/usr/bin/rug verify -y$"; # $ means no args
+	package_verify_command        => "/usr/bin/rug verify -y$"; # $ means no args
+
 }

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -676,7 +676,7 @@ bundle agent check_binaries_freshness
 
     community_edition::
 
-      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key" };
+      "components" slist => { "cf-agent", "cf-serverd", "cf-execd", "cf-monitord", "cf-promises", "cf-runagent", "cf-key", "rpmvercmp" };
 
     nova_edition::
 

--- a/techniques/system/common/1.0/rudder_lib.st
+++ b/techniques/system/common/1.0/rudder_lib.st
@@ -22,6 +22,42 @@
 #
 #####################################################################################
 
+###################################################
+# Knowledge from the original stdlib
+###################################################
+# Uses a specific prefix to avoid collision
+# when the stdlib will be updated
+###################################################
+
+bundle common rudder_debian_knowledge
+# @depends paths
+# @brief common Rudder Debian knowledge bundle
+#
+# This common bundle has useful information about Debian.
+{
+  vars:
+
+      "dpkg_compare_equal" string => "/usr/bin/dpkg --compare-versions '${v1}' eq '${v2}'";
+      "dpkg_compare_less"  string => "/usr/bin/dpkg --compare-versions '${v1}' lt '${v2}'";
+
+}
+
+
+bundle common rudder_rpm_knowledge
+# @depends paths
+# @brief common Rudder RPM knowledge bundle
+#
+# This common bundle has useful information about platforms using RPM
+{
+  vars:
+
+      "rpm_compare_equal" string => "${sys.workdir}/bin/rpmvercmp '${v1}' eq '${v2}'";
+      "rpm_compare_less"  string => "${sys.workdir}/bin/rpmvercmp '${v1}' lt '${v2}'";
+
+}
+
+###################################################
+
 body depth_search recurse_visible(d)
 {
         depth        => "${d}";
@@ -119,17 +155,19 @@ body location append
 #########################################################
 body package_method yum_remi
 {
-        package_changes            => "bulk";
-        package_list_command       => "/usr/bin/yum list installed";
-        package_list_name_regex    => "([^.]+).*";
-        package_list_version_regex => "[^\s]\s+([^\s]+).*";
-        package_list_arch_regex    => "[^.]+\.([^\s]+).*";
-        package_installed_regex    => ".*installed.*";
-        package_name_convention    => "${name}.${arch}";
-        package_delete_convention  => "${name}";
-        package_add_command        => "/usr/bin/yum --enablerepo=remi -y install";
-        package_delete_command     => "/bin/rpm -e";
-        package_verify_command     => "/bin/rpm -V";
+
+        package_changes               => "bulk";
+        package_list_command          => "/usr/bin/yum list installed";
+        package_list_name_regex       => "([^.]+).*";
+        package_list_version_regex    => "[^\s]\s+([^\s]+).*";
+        package_list_arch_regex       => "[^.]+\.([^\s]+).*";
+        package_installed_regex       => ".*installed.*";
+        package_name_convention       => "${name}.${arch}";
+        package_delete_convention     => "${name}";
+        package_add_command           => "/usr/bin/yum --enablerepo=remi -y install";
+        package_delete_command        => "/bin/rpm -e";
+        package_verify_command        => "/bin/rpm -V";
+
 }
 
 #perms validation
@@ -446,7 +484,7 @@ body file_select date_pattern(age, pattern)
 body package_method rudder_rug
 {
 
-        package_changes => "individual";
+        package_changes               => "individual";
 
         package_list_command          => "/bin/rpm -qa --queryformat \"i | repos | %{name} | %{version}-%{release} | %{arch}\n\"";
         package_list_update_ifelapsed => "240";
@@ -461,6 +499,11 @@ body package_method rudder_rug
         package_update_command        => "/usr/bin/rug update -y";
 
         package_verify_command        => "/usr/bin/rug verify -y$"; # $ means no args
+
+        # make correct version comparisons
+        package_version_less_command  => "${rudder_rpm_knowledge.rpm_compare_less}";
+        package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
+
 }
 
 ########################################################################
@@ -469,23 +512,27 @@ body package_method rudder_rug
 body package_method rudder_yum
 {
 
- package_changes => "bulk";
- package_list_command => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
- package_list_name_regex    => "^(\S+?)\s\S+?\s\S+$";
- package_list_version_regex => "^\S+?\s(\S+?)\s\S+$";
- package_list_arch_regex    => "^\S+?\s\S+?\s(\S+)$";
- package_installed_regex => ".*";
- package_name_convention => "${name}";
- package_list_update_command => "/usr/bin/yum --quiet check-update";
- package_list_update_ifelapsed => "240";
- package_patch_name_regex    => "([^.]+).*";
- package_patch_version_regex => "[^\s]\s+([^\s]+).*";
- package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
- package_add_command    => "/usr/bin/yum -y install";
- package_update_command => "/usr/bin/yum -y update";
- package_patch_command => "/usr/bin/yum -y update";
- package_delete_command => "/bin/rpm -e --nodeps --allmatches";
- package_verify_command => "/bin/rpm -V";
+  package_changes               => "bulk";
+  package_list_command          => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+  package_list_name_regex       => "^(\S+?)\s\S+?\s\S+$";
+  package_list_version_regex    => "^\S+?\s(\S+?)\s\S+$";
+  package_list_arch_regex       => "^\S+?\s\S+?\s(\S+)$";
+  package_installed_regex       => ".*";
+  package_name_convention       => "${name}";
+  package_list_update_command   => "/usr/bin/yum --quiet check-update";
+  package_list_update_ifelapsed => "240";
+  package_patch_name_regex      => "([^.]+).*";
+  package_patch_version_regex   => "[^\s]\s+([^\s]+).*";
+  package_patch_arch_regex      => "[^.]+\.([^\s]+).*";
+  package_add_command           => "/usr/bin/yum -y install";
+  package_update_command        => "/usr/bin/yum -y update";
+  package_patch_command         => "/usr/bin/yum -y update";
+  package_delete_command        => "/bin/rpm -e --nodeps --allmatches";
+  package_verify_command        => "/bin/rpm -V";
+
+  # make correct version comparisons
+  package_version_less_command  => "${rudder_rpm_knowledge.rpm_compare_less}";
+  package_version_equal_command => "${rudder_rpm_knowledge.rpm_compare_equal}";
 
 }
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/5595

To be merged in 2.10
