### PR TITLE
Fixes #5775: Correct AIX log parsing (Strip 'Message forwarded from <hos...

### DIFF
--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
@@ -29,6 +29,13 @@ $UDPServerRun &SYSLOGPORT&
 # for Snare client
 $EscapeControlCharactersOnReceive off
 
+# for AIX clients
+# (strips "Message forwarded from" from the message)
+$ModLoad pmaixforwardedfrom
+$RulesetParser rsyslog.aixforwardedfrom
+$RulesetParser rsyslog.rfc5424
+$RulesetParser rsyslog.rfc3164
+
 # Log everything
 *.*	/var/log/rudder/reports/all.log
 

--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-root.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-root.st
@@ -35,6 +35,13 @@ $ModLoad ompgsql
 # for Snare client
 $EscapeControlCharactersOnReceive off
 
+# for AIX clients
+# (strips "Message forwarded from" from the message)
+$ModLoad pmaixforwardedfrom
+$RulesetParser rsyslog.aixforwardedfrom
+$RulesetParser rsyslog.rfc5424
+$RulesetParser rsyslog.rfc3164
+
 # Log everything
 *.*	/var/log/rudder/reports/all.log
 


### PR DESCRIPTION
...tname>' header)

Ticket: http://www.rudder-project.org/redmine/issues/5775

To be merged in 2.10
