### PR TITLE
Fixes #5874: Start message from system techniques is sometimes not print...

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -170,7 +170,9 @@ bundle agent startup
     # Always do it in "full_compliance" mode
     # In other modes, only do it here if we need to send it as a "heartbeat", that is if it hasn't already been sent recently enough
     full_compliance|!heartbeat_sent::
-      "Send start message" usebundle => startExecution;
+      "Send start message"
+        usebundle => startExecution,
+        action    => immediate;
 }
 
 bundle agent startExecution

--- a/techniques/system/common/1.0/rudder_stdlib.st
+++ b/techniques/system/common/1.0/rudder_stdlib.st
@@ -193,7 +193,9 @@ bundle agent rudder_common_report(technique_name, status, identifier, component_
   methods:
     # If we need to send a report, make sure we have sent the "StartRun" message first
     send_reports.!start_run_message_sent::
-      "Send start message" usebundle => startExecution;
+      "Send start message"
+        usebundle => startExecution,
+        action    => immediate;
 
   reports:
     full_compliance|send_reports::


### PR DESCRIPTION
...ed due to over-zealous locking
