### PR TITLE
Fixes #5922: Redirect the output of rudder-agent-check to /dev/null (3.0...

### DIFF
--- a/techniques/system/common/1.0/rudder_agent_community_cron.st
+++ b/techniques/system/common/1.0/rudder_agent_community_cron.st
@@ -9,4 +9,4 @@
 # /opt/rudder/etc/rudder-restart-message.txt file with your custom message inside. It will be sent by mail
 # instead of the default one.
 
-0,5,10,15,20,25,30,35,40,45,50,55 * * * * root /opt/rudder/bin/check-rudder-agent
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * root /opt/rudder/bin/check-rudder-agent >/dev/null


### PR DESCRIPTION
... style)

Ticket: https://www.rudder-project.org/redmine/issues/5922

to be merged in 3.0
