### PR TITLE
Fixes #6000: Error output on Time settings at first run

### DIFF
--- a/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
@@ -143,6 +143,8 @@ bundle agent check_clock_configuration
       "clock_set_norway" expression => strcmp("&CLOCK_TIMEZONE&","norway");
       "clock_set_beijing" expression => strcmp("&CLOCK_TIMEZONE&","beijing");
 
+      "ntp_config_file_exists" expression => fileexists("/etc/ntp.conf");
+
     clock_vardef.windows::
       # check if we need to change the windows timezone
       "need_to_change_timezone" not => strcmp("${windows_timezone}", "${current_timezone}");
@@ -236,7 +238,7 @@ bundle agent check_clock_configuration
   files:
 
     # Adjust ntp.conf (Add the servers)
-    !windows::
+    !windows.(ntp_config_file_exists|ntp_installed)::
       "/etc/ntp.conf"
         edit_line => setNtpServer("@{this.ntpServers}"),
         edit_defaults => noempty_backup,

--- a/techniques/systemSettings/misc/clockConfiguration/2.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/2.0/clockConfiguration.st
@@ -143,6 +143,7 @@ bundle agent check_clock_configuration
       "clock_set_norway" expression => strcmp("&CLOCK_TIMEZONE&","norway");
       "clock_set_beijing" expression => strcmp("&CLOCK_TIMEZONE&","beijing");
 
+      "ntp_config_file_exists" expression => fileexists("/etc/ntp.conf");
 
     clock_vardef.windows::
       # check if we need to change the windows timezone
@@ -151,7 +152,7 @@ bundle agent check_clock_configuration
   files:
 
     # Adjust ntp.conf (Add the servers)
-    !windows::
+    !windows.(ntp_config_file_exists|ntp_installed)::
       "/etc/ntp.conf"
         edit_line => setNtpServer("@{this.ntpServers}"),
         edit_defaults => noempty_backup,


### PR DESCRIPTION
Fix for http://www.rudder-project.org/redmine/issues/6000, on 2.10 branch (oldest supported) for versions 1.0 and 2.0. The bug is also present in version 3.0 in branch 2.11, a new PR for that version is coming.
