### PR TITLE
Fixes #6089: enforce file content post modification hook if section is modified but global state of the file is not changed

### DIFF
--- a/techniques/fileDistribution/checkGenericFileContent/5.0/checkGenericFileContent.st
+++ b/techniques/fileDistribution/checkGenericFileContent/5.0/checkGenericFileContent.st
@@ -150,7 +150,7 @@ classes:
       "$(generic_file_content_posthook[$(index)])"
         classes => if_else("generic_file_content_posthook_$(index)_command_run_ok", "generic_file_content_posthook_$(index)_command_run_failed"),
         contain => in_shell,
-        ifvarclass => "execute_command_$(index).file_edition_global_files_status_$(index)_repaired";
+        ifvarclass => "execute_command_$(index).(file_edition_global_files_status_$(index)_repaired|content_$(index)_modified|content_deletion_modified_$(index)|content_modification_modified_$(index)|section_content_modification_modified_${index})";
 
   reports:
     tier2::

--- a/techniques/fileDistribution/checkGenericFileContent/6.0/checkGenericFileContent.st
+++ b/techniques/fileDistribution/checkGenericFileContent/6.0/checkGenericFileContent.st
@@ -185,7 +185,7 @@ classes:
       "${generic_file_content_posthook[${index}]}"
         classes => if_else("generic_file_content_posthook_${index}_command_run_ok", "generic_file_content_posthook_${index}_command_run_failed"),
         contain => in_shell,
-        ifvarclass => "execute_command_${index}.file_edition_global_files_status_${index}_repaired";
+        ifvarclass => "execute_command_${index}.(file_edition_global_files_status_$(index)_repaired|content_$(index)_modified|content_deletion_modified_$(index)|content_modification_modified_$(index)|section_content_modification_modified_${index})";
 
   reports:
     tier2::


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6089