### PR TITLE
Fixes #6181: Allow cf-serverd to listen on an alternate port

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -185,8 +185,10 @@ body server control
 
         skipverify        => { "127.0.0.0/8" , "::1",  @{def.acl}  };
 
-    community_edition::
+    community_edition.!debug_port::
         port => "&COMMUNITYPORT&";
+    community_edition.debug_port::
+        port => "5310";
 
 }
 
@@ -202,8 +204,10 @@ body runagent control
 
         max_children => "25";
 
-    community_edition::
+    community_edition.!debug_port::
         port => "&COMMUNITYPORT&";
+    community_edition.debug_port::
+        port => "5310";
 }
 &endif&
 


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6181