### PR TITLE
Fixes #6385: Remove /var/log/rudder/compliance/non-compliant-reports.log rotation from logrotate

### DIFF
--- a/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.debian
+++ b/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.debian
@@ -53,22 +53,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-        delaycompress
-}

--- a/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.old-debian
+++ b/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.old-debian
@@ -52,20 +52,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-}

--- a/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.rhel
+++ b/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.rhel
@@ -56,22 +56,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}

--- a/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.suse
+++ b/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.suse
@@ -39,22 +39,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}

--- a/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.ubuntu
+++ b/initial-promises/node-server/distributePolicy/logrotate.conf/rudder.ubuntu
@@ -52,20 +52,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-}

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder
@@ -38,12 +38,3 @@
 	delaycompress
 }
 
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root root
-	delaycompress
-}

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.debian
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.debian
@@ -38,12 +38,3 @@
 		create 640 root adm
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        delaycompress
-        notifempty
-        create 640 root adm
-}

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.rhel
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.rhel
@@ -56,12 +56,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.suse
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.suse
@@ -32,12 +32,3 @@
 		create 640 root root
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        delaycompress
-        notifempty
-        create 640 root root
-}

--- a/techniques/system/distributePolicy/1.0/logrotate.debian.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.debian.st
@@ -53,22 +53,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-        delaycompress
-}

--- a/techniques/system/distributePolicy/1.0/logrotate.old-debian.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.old-debian.st
@@ -52,20 +52,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-}

--- a/techniques/system/distributePolicy/1.0/logrotate.rhel.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.rhel.st
@@ -56,22 +56,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}

--- a/techniques/system/distributePolicy/1.0/logrotate.suse.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.suse.st
@@ -39,22 +39,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root root
-        delaycompress
-}

--- a/techniques/system/distributePolicy/1.0/logrotate.ubuntu.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.ubuntu.st
@@ -52,20 +52,3 @@
         endscript
 }
 
-/var/log/rudder/core/*.log {
-        daily
-        missingok
-        rotate 30
-        compress
-        notifempty
-        create 640 root adm
-}
-
-/var/log/rudder/compliance/non-compliant-reports.log {
-        daily
-        missingok
-        rotate 365
-        compress
-        notifempty
-        create 640 root adm
-}


### PR DESCRIPTION
Removing in 3 places. 
Be carefull, the up-merge will imply changing in other place (node-roles)