### PR TITLE
Fixes #6526: Do not rotate syslog using init.d on RHEL

### DIFF
--- a/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.rhel
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/distributePolicy/logrotate.conf/rudder.rhel
@@ -38,7 +38,7 @@
         create 640 root root
         delaycompress
         postrotate
-          /etc/init.d/rsyslog reload > /dev/null
+          /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }
 
@@ -52,7 +52,7 @@
         delaycompress
         sharedscripts
         postrotate
-          /etc/init.d/rsyslog reload > /dev/null
+          /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }
 

--- a/techniques/system/distributePolicy/1.0/logrotate.rhel.st
+++ b/techniques/system/distributePolicy/1.0/logrotate.rhel.st
@@ -38,7 +38,7 @@
         create 640 root root
         delaycompress
         postrotate
-          /etc/init.d/rsyslog reload > /dev/null
+          /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }
 
@@ -52,7 +52,7 @@
         delaycompress
         sharedscripts
         postrotate
-          /etc/init.d/rsyslog reload > /dev/null
+          /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }
 


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6548

To be merged in 2.10