### PR TITLE
Fixes #6574: Promise generation fails - string_downcase isn't a valid syntax on 2.10

### DIFF
--- a/initial-promises/node-server/common/1.0/cf-served.cf
+++ b/initial-promises/node-server/common/1.0/cf-served.cf
@@ -61,7 +61,7 @@ bundle server access_rules
     any::
       # Allow server to remotely run the agent
       "/var/rudder/cfengine-community/bin/cf-agent"
-        admit   => { host2ip("${server_info.cfserved}"), string_downcase(escape("${server_info.cfserved}")) };
+        admit   => { host2ip("${server_info.cfserved}"), escape("${server_info.cfserved}") };
 
   roles:
       # Allow user root to set any class

--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -88,7 +88,7 @@ bundle server access_rules
     any::
       # Allow server to remotely run the agent
       "/var/rudder/cfengine-community/bin/cf-agent"
-        admit   => { host2ip("${server_info.cfserved}"), string_downcase(escape("${server_info.cfserved}")) };
+        admit   => { host2ip("${server_info.cfserved}"), escape("${server_info.cfserved}") };
 
   roles:
       # Allow user root to set any class


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6574