### PR TITLE
Fixes #6450: Correct Beijing's time zone

### DIFF
--- a/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/1.0/clockConfiguration.st
@@ -118,7 +118,7 @@ bundle agent check_clock_configuration
 
     clock_set_beijing::
 
-      "linux_timezone" string => "Europe/Paris";
+      "linux_timezone" string => "Asia/Shanghai";
       "windows_timezone" string => "China Standard Time";
 
   classes:

--- a/techniques/systemSettings/misc/clockConfiguration/2.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/2.0/clockConfiguration.st
@@ -118,7 +118,7 @@ bundle agent check_clock_configuration
 
     clock_set_beijing::
 
-      "linux_timezone" string => "Europe/Paris";
+      "linux_timezone" string => "Asia/Shanghai";
       "windows_timezone" string => "China Standard Time";
 
   classes:


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/6450

To be merged in 2.10