### PR TITLE
Fixes #6742: postgres-check still uses /etc/init.d/ for service management

### DIFF
--- a/initial-promises/node-server/server-roles/1.0/postgres-check.cf
+++ b/initial-promises/node-server/server-roles/1.0/postgres-check.cf
@@ -39,7 +39,7 @@ bundle agent root_postgres_check
 
     SuSE::
 
-      "/etc/init.d/postgresql"
+      "/sbin/service postgresql"
         args => "restart",
         classes => kept_if_else("psql_restart_ok", "psql_restart_ok", "psql_restart_error"),
         ifvarclass => "psql_conf_updated";


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6742