### PR TITLE
Fixes #6743: generic_process_check_process in init-check still uses /etc/init.d

### DIFF
--- a/initial-promises/node-server/server-roles/1.0/init-check.cf
+++ b/initial-promises/node-server/server-roles/1.0/init-check.cf
@@ -44,7 +44,7 @@ bundle agent generic_process_check_process(binary, initscript, name, force_resta
 
     root_server|process_exception_on_relay::
 
-      "/etc/init.d/${initscript}"
+      "${paths.path[service]} ${initscript}"
         args => "restart </dev/null >/dev/null 2>/dev/null",
         contain => in_shell_silent,
       # action => bg("0", "120"),


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6743