### PR TITLE
Fixes #6845: Nodes using syslogd coninue to report to their old server when changing their policy server

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -790,17 +790,16 @@ bundle edit_line enforce_content(str)
 bundle edit_line fix_syslogd(syslogd)
 {
   delete_lines:
-    any::
-      "^(local6)\s+(?!${syslogd}).*"
-        comment => "Delete missconfigured rudder syslogd destination";
-      "^local6\.\*\s+${syslogd}"
-        comment => "Delete old rudder syslogd format";
+
+      "^\s*local6.*"
+        comment => "Delete all local6 facility related lines";
 
   insert_lines:
-    any::
+
       "# Rudder specific logging parameters";
-      "local6.notice					${syslogd}"
+      "local6.notice ${syslogd}"
         comment => "Add the rudder syslogd destination";
+
 }
 
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6845