### PR TITLE
Fixes #6907: Rudder relay rsyslog configuration still have AllowedSender directives

### DIFF
--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
@@ -57,23 +57,3 @@ $ActionQueueSaveOnShutdown on
 ## Syslog messages from "rudder" forwarded from AIX
 :msg, ereregex, "from .*: rudder" ~
 
-# Access Control list, localhost + all known agents 
-$AllowedSender UDP, 127.0.0.0/8
-$AllowedSender TCP, 127.0.0.0/8
-
-&if(SKIPIDENTIFY)&
-
-&AUTHORIZED_NETWORKS:{net|
-$AllowedSender UDP, &net&
-$AllowedSender TCP, &net&
-}&
-
-&else&
-
-&MANAGED_NODES_IP : {ip |
-$AllowedSender UDP, &ip&
-$AllowedSender TCP, &ip&
-} &
-
-&endif&
-


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6907