### PR TITLE
Fixes #6916: We can't use cf-runagent because port is not taken into …

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -206,10 +206,20 @@ body server control
 &if(MANAGED_NODES_NAME)&
 body runagent control
 {
+  &if(NOVA)&
+  # If using enterprise, the nodes to connect to are using default port
         hosts => {
           &MANAGED_NODES_NAME: {
           "&it&",}&
         };
+  &else&
+  # When using community, we must use the port &COMMUNITYPORT& to connect to nodes
+        hosts => {
+          &MANAGED_NODES_NAME: {
+          "&it&:&COMMUNITYPORT&",}&
+        };
+
+  &endif&
 
         max_children => "25";
 


### PR DESCRIPTION
…account in the body runagent control