### PR TITLE
Fixes #6933: Rudder should not attempt to check if the \"rudder\" service is started at boot

### DIFF
--- a/techniques/system/common/1.0/metadata.xml
+++ b/techniques/system/common/1.0/metadata.xml
@@ -96,7 +96,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <SECTION name="Red Button" component="true" />
     <SECTION name="Security parameters" component="true" />
     <SECTION name="Update" component="true" />
-    <SECTION name="Check rudder service bootstart parameters" component="true" />
     <SECTION name="Log system for reports" component="true" />
     <SECTION name="CRON Daemon" component="true" />
     <SECTION name="Binaries update" component="true" />

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -54,7 +54,6 @@ bundle common va
         "check_red_button_status",
         "process_matching",
         "check_cf_processes",
-        "check_rudder_service_bootstart_parameters",
         "check_uuid",
         "check_rsyslog_version",
         "check_cron_daemon",
@@ -88,7 +87,6 @@ bundle common va
         "check_rsyslog_version",
         "nxlog_enable",
         "check_zypper",
-        "check_rudder_service_bootstart_parameters",
         "check_uuid",
         "get_environment_variables",
         "configuration"
@@ -437,18 +435,6 @@ bundle agent check_cf_processes
       "${sys.cf_execd}"
         action  => u_ifwin_bg,
         classes => outcome("executor");
-
-}
-
-#######################################################
-# Check that the rudder service is started at boot
-#######################################################
-bundle agent check_rudder_service_bootstart_parameters {
-
-  methods:
-
-      "bootstart_service" usebundle => service_ensure_started_at_boot("rudder");
-      "bootstart_report"  usebundle => rudder_common_reports_generic("Common", "service_ensure_started_at_boot_rudder", "&TRACKINGKEY&", "Check rudder service bootstart parameters", "None", "Check if Rudder is set to start on boot");
 
 }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6933