### PR TITLE
Fixes #7098: When syslog-ng is replaced by rsyslogd on SuSE, service is not restarted

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -56,6 +56,7 @@ bundle common va
         "process_matching",
         "check_cf_processes",
         "check_uuid",
+        "check_log_system",
         "check_rsyslog_version",
         "check_cron_daemon",
         "garbage_collection",
@@ -68,7 +69,7 @@ bundle common va
 
       # On the policy server, we do the check_log_system at the end, to ensure that rsyslog has been installed and configured before.
 
-      "end" slist => { "check_log_system", "endExecution" };
+      "end" slist => { "restart_services", "endExecution" };
 
     !policy_server::
       "bs" slist => {
@@ -454,7 +455,6 @@ bundle agent check_uuid
         comment       => "Setting the uuid variable in a machine";
 }
 
-
 #######################################################
 # Check the log system, and configure it accordingly
 # This only works with unix flavoured system
@@ -501,6 +501,7 @@ bundle agent check_log_system
       "pass1" expression => "any";
 
   files:
+
     !windows.rsyslogd::
       "/etc/rsyslog.conf"
         edit_line => append_if_no_lines("$IncludeConfig /etc/rsyslog.d/*.conf"),
@@ -546,22 +547,6 @@ bundle agent check_log_system
 
     pass2.rsyslogd::
       "any" usebundle => rudder_common_report("Common", "log_info", "&TRACKINGKEY&", "Log system for reports", "None", "Detected running syslog as rsyslog");
-
-    pass2.((SuSE.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired))|((!SuSE.!aix.!solaris).syslogd_repaired))::
-
-      "restart_syslog"    usebundle => service_restart("syslog");
-
-    pass2.!SuSE.syslog_ng_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("syslog-ng");
-
-    pass2.!SuSE.rsyslog_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("rsyslog");
-
-    pass2.!SuSE.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired)::
-
-      "restart_syslog" usebundle => service_restart("syslog");
 
     pass3.(syslogd_failed|syslog_ng_failed|rsyslog_failed)::
       "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Logging system could not be configured for report centralization");
@@ -615,14 +600,6 @@ bundle agent check_rsyslog_version {
 
   methods:
 
-    pass2.!SuSE.rsyslog_limit_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("rsyslog");
-
-    pass2.SuSE.rsyslog_limit_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("syslog");
-
     pass3.(rsyslogd.!check_rsyslog_version_present)::
       "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "The file  ${g.rudder_tools}/check-rsyslog-version is missing");
 
@@ -631,12 +608,6 @@ bundle agent check_rsyslog_version {
 
     pass3.rsyslog_limit_repaired::
       "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Updated the rsyslog configuration to remove limitation of messages");
-
-    pass3.(service_restart_rsyslog_repaired|service_restart_syslog_repaired)::
-      "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Configured logging system for report centralization");
-
-    pass3.(service_restart_rsyslog_not_ok|service_restart_syslog_not_ok)::
-      "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not restart the logging system");
 
   commands:
     rsyslogd.check_rsyslog_version_present::
@@ -753,6 +724,51 @@ bundle agent check_binaries_freshness
 
     nova_edition::
       "any" usebundle => rudder_common_report("Common", "result_na", "&TRACKINGKEY&", "Binaries update", "None", "This is an CFEngine enterprise system: binaries update are handled differently");
+
+}
+
+#######################################################
+# Restart needed services (at the end)
+
+bundle agent restart_services
+{
+  classes:
+
+    any::
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
+  
+  methods:
+  
+    # log services
+
+    pass2.(!SuSE.!aix.!solaris).syslogd_repaired::
+
+      "restart_syslog"    usebundle => service_restart("syslog");
+
+    pass2.syslog_ng_repaired.!SuSE::
+
+      "restart_syslog_ng" usebundle => service_restart("syslog-ng");
+
+    pass2.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired).!SuSE::
+
+      "restart_syslog" usebundle => service_restart("syslog");
+
+    pass2.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired|rsyslog_repaired|rsyslog_limit_repaired).!SuSE::
+
+      "restart_rsyslog" usebundle => service_restart("rsyslog");
+
+    pass2.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired|syslog_ng_repaired|rsyslog_repaired|syslogd_repaired|rsyslog_limit_repaired).SuSE::
+
+      "restart_rsyslog" usebundle => service_restart("syslog");
+      
+    # reporting for check_rsyslog_version
+    pass3.(service_restart_rsyslog_repaired|service_restart_syslog_repaired).syslog_limit_repaired::
+      "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Configured logging system for report centralization");
+
+    pass3.(service_restart_rsyslog_not_ok|service_restart_syslog_not_ok).syslog_limit_repaired::
+      "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not restart the logging system");
 
 }
 

--- a/techniques/system/distributePolicy/1.0/rsyslogConf.st
+++ b/techniques/system/distributePolicy/1.0/rsyslogConf.st
@@ -97,16 +97,6 @@ bundle agent install_rsyslogd {
         classes => cf2_if_else("rsyslog_pgsql_installed", "cant_install_rsyslog_pgsql"),
         comment => "Installing rsyslog_pgsql using apt backports";
 
-  methods:
-
-    policy_server.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired).!SuSE::
-
-      "rsyslog_restart" usebundle => service_restart("rsyslog");
-
-    policy_server.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired).SuSE::
-
-      "rsyslog_restart" usebundle => service_restart("syslog");
-
   reports:
 
     cant_install_rsyslog|cant_install_rsyslog_pgsql::


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7098