### PR TITLE
Fixes #7098: When syslog-ng is replaced by rsyslogd on SuSE, service …

### DIFF
--- a/techniques/system/common/1.0/metadata.xml
+++ b/techniques/system/common/1.0/metadata.xml
@@ -59,6 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <INCLUDED>false</INCLUDED>
     </TML>
     <TML name="environment-variables"/>
+    <TML name="restart-services"/>
   </TMLS>
 
   <SYSTEMVARS>

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -43,7 +43,11 @@ body common control
 bundle common va
 {
   vars:
+
+      "end" slist => { "restart_services", "endExecution" };
+
     policy_server::
+
       "bs" slist => {
         "startup",
         "check_disable_agent",
@@ -56,6 +60,7 @@ bundle common va
         "process_matching",
         "check_cf_processes",
         "check_uuid",
+        "check_log_system",
         "check_rsyslog_version",
         "check_cron_daemon",
         "garbage_collection",
@@ -66,11 +71,8 @@ bundle common va
         "configuration"
       };
 
-      # On the policy server, we do the check_log_system at the end, to ensure that rsyslog has been installed and configured before.
-
-      "end" slist => { "check_log_system", "endExecution" };
-
     !policy_server::
+
       "bs" slist => {
         "startup",
         "check_disable_agent",
@@ -93,8 +95,6 @@ bundle common va
         "get_environment_variables",
         "configuration"
       };
-
-      "end" slist => { "endExecution" };
 
     !android.!windows::
       "rudder_var"     string => "/var/rudder";
@@ -454,7 +454,6 @@ bundle agent check_uuid
         comment       => "Setting the uuid variable in a machine";
 }
 
-
 #######################################################
 # Check the log system, and configure it accordingly
 # This only works with unix flavoured system
@@ -501,6 +500,7 @@ bundle agent check_log_system
       "pass1" expression => "any";
 
   files:
+
     !windows.rsyslogd::
       "/etc/rsyslog.conf"
         edit_line => append_if_no_lines("$IncludeConfig /etc/rsyslog.d/*.conf"),
@@ -546,22 +546,6 @@ bundle agent check_log_system
 
     pass2.rsyslogd::
       "any" usebundle => rudder_common_report("Common", "log_info", "&TRACKINGKEY&", "Log system for reports", "None", "Detected running syslog as rsyslog");
-
-    pass2.((SuSE.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired))|((!SuSE.!aix.!solaris).syslogd_repaired))::
-
-      "restart_syslog"    usebundle => service_restart("syslog");
-
-    pass2.!SuSE.syslog_ng_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("syslog-ng");
-
-    pass2.!SuSE.rsyslog_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("rsyslog");
-
-    pass2.!SuSE.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired)::
-
-      "restart_syslog" usebundle => service_restart("syslog");
 
     pass3.(syslogd_failed|syslog_ng_failed|rsyslog_failed)::
       "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Logging system could not be configured for report centralization");
@@ -615,14 +599,6 @@ bundle agent check_rsyslog_version {
 
   methods:
 
-    pass2.!SuSE.rsyslog_limit_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("rsyslog");
-
-    pass2.SuSE.rsyslog_limit_repaired::
-
-      "restart_syslog_ng" usebundle => service_restart("syslog");
-
     pass3.(rsyslogd.!check_rsyslog_version_present)::
       "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "The file  ${g.rudder_tools}/check-rsyslog-version is missing");
 
@@ -631,12 +607,6 @@ bundle agent check_rsyslog_version {
 
     pass3.rsyslog_limit_repaired::
       "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Updated the rsyslog configuration to remove limitation of messages");
-
-    pass3.(service_restart_rsyslog_repaired|service_restart_syslog_repaired)::
-      "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Configured logging system for report centralization");
-
-    pass3.(service_restart_rsyslog_not_ok|service_restart_syslog_not_ok)::
-      "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not restart the logging system");
 
   commands:
     rsyslogd.check_rsyslog_version_present::

--- a/techniques/system/common/1.0/restart-services.st
+++ b/techniques/system/common/1.0/restart-services.st
@@ -1,0 +1,59 @@
+#####################################################################################
+# Copyright 2015- Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+#######################################################
+#
+# restart_services
+#
+# This bundle restarts all the services in need at the end
+# of the agent execution
+#
+#######################################################
+
+bundle agent restart_services
+{
+  
+  methods:
+  
+    # (sys)log service
+
+    (!SuSE.!aix.!solaris).syslogd_repaired::
+
+      "restart_syslog" usebundle => service_restart("syslog");
+
+    !SuSE.syslog_ng_repaired::
+
+      "restart_syslog_ng" usebundle => service_restart("syslog-ng");
+
+    !SuSE.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired|rsyslog_repaired|rsyslog_limit_repaired)::
+
+      "restart_rsyslog" usebundle => service_restart("rsyslog");
+
+    SuSE.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired|syslog_ng_repaired|rsyslog_repaired|syslogd_repaired|rsyslog_limit_repaired)::
+
+      "restart_rsyslog" usebundle => service_restart("syslog");
+      
+    # Final report about (sys)log setting enforcement / restart
+
+    service_restart_rsyslog_repaired|service_restart_syslog_ng_repaired|service_restart_syslog_repaired::
+      "any" usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Logging system has been restarted");
+
+    service_restart_rsyslog_not_ok|service_restart_syslog_ng_not_ok|service_restart_syslog_not_ok::
+      "any" usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not restart the logging system");
+
+}

--- a/techniques/system/distributePolicy/1.0/rsyslogConf.st
+++ b/techniques/system/distributePolicy/1.0/rsyslogConf.st
@@ -97,16 +97,6 @@ bundle agent install_rsyslogd {
         classes => cf2_if_else("rsyslog_pgsql_installed", "cant_install_rsyslog_pgsql"),
         comment => "Installing rsyslog_pgsql using apt backports";
 
-  methods:
-
-    policy_server.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired).!SuSE::
-
-      "rsyslog_restart" usebundle => service_restart("rsyslog");
-
-    policy_server.(rsyslog_installed|rsyslog_pgsql_installed|rudder_rsyslog_conf_copied|rudder_rsyslog_pgsql|rudder_rsyslog_historical_conf_purged_repaired).SuSE::
-
-      "rsyslog_restart" usebundle => service_restart("syslog");
-
   reports:
 
     cant_install_rsyslog|cant_install_rsyslog_pgsql::


### PR DESCRIPTION
…is not restarted

Co-Authored-By: Matthieu CERDA <matthieu.cerda@normation.com>

Ticket: https://www.rudder-project.org/redmine/issues/7098