### PR TITLE
Fixing #7268 for apache24 network list

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -118,7 +118,7 @@ bundle common def
     policy_server::
       "acl" slist => {
       "127.0.0.0/8" , "::1",
-      "${def.policy_server}", # the policy server can connect to a relay
+      host2ip("${def.policy_server}"), # the policy server can connect to a relay
       &AUTHORIZED_NETWORKS:{net|"&net&",}&
     };
 &endif&


### PR DESCRIPTION
Make sure the allow list only consists of IP-s, otherwise it will break apache 2.4's Require IP statements.