### PR TITLE
Fixes #6714: Compress ldap backups

### DIFF
--- a/techniques/system/server-roles/1.0/component-check.st
+++ b/techniques/system/server-roles/1.0/component-check.st
@@ -144,6 +144,7 @@ bundle agent root_component_check
     role_rudder_inventory_ldap::
       "any" usebundle => generic_process_check_process("${service[rudder_slapd][binary]}", "${service[rudder_slapd][initscript]}", "${service[rudder_slapd][name]}", "false", "${service[rudder_slapd][check_on_relay_server]}");
       "any" usebundle => generic_process_check_bootstart("${service[rudder_slapd][binary]}", "${service[rudder_slapd][initscript]}", "${service[rudder_slapd][name]}");
+      "any" usebundle => compress_ldap_backups;
 
     !role_rudder_inventory_ldap::
       "any" usebundle => rudder_common_report("${technique_name}", "result_na", "&TRACKINGKEY&",

--- a/techniques/system/server-roles/1.0/compress-ldap-backups.st
+++ b/techniques/system/server-roles/1.0/compress-ldap-backups.st
@@ -1,0 +1,32 @@
+#####################################################################################
+# Copyright 2014 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+bundle agent compress_ldap_backups
+{
+  vars:
+    # compres openldap-data-*.ldif files
+    "backups_pattern" slist => { "openldap-data-.*\.ldif" };
+
+  files:
+    "/var/rudder/ldap/backup"
+      file_select => by_name("@{backups_pattern}"),
+      depth_search => recurse("0"),
+      transformer => "${g.gzip} \"${this.promiser}\"";
+
+}

--- a/techniques/system/server-roles/1.0/metadata.xml
+++ b/techniques/system/server-roles/1.0/metadata.xml
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <TML name="postgres-check"/>
     <TML name="logrotate-check"/>
     <TML name="compress-webapp-log"/>
+    <TML name="compress-ldap-backups"/>
     <TML name="rudder-logrotate">
       <OUTPATH>server-roles/logrotate.conf/rudder</OUTPATH>
       <INCLUDED>false</INCLUDED>


### PR DESCRIPTION
Every time slapd is restarted, it writes a backup, that can get big in time
This modification compresses every uncompressed ldif-backups with gzip just
like the webapp-logs.