### PR TITLE
Fixes #7206: Touch file on inventory sent

### DIFF
--- a/initial-promises/node-server/inventory/1.0/fusionAgent.cf
+++ b/initial-promises/node-server/inventory/1.0/fusionAgent.cf
@@ -517,6 +517,11 @@ bundle agent sendInventory
         classes      => if_else("inventory_file_deleted", "cant_delete_inventory_file"),
         comment      => "Cleaning up inventory files already sent to the server";
 
+      "${g.rudder_var_tmp}/inventory_sent"
+        create       => "true",
+        touch        => "true",
+        comment      => "Create local info about successful upload";
+
       "${g.rudder_var_tmp}/inventory"
         transformer  => "${g.rudder_rm} -f ${this.promiser}",
         depth_search => recurse_visible(1),


### PR DESCRIPTION
This fix creates and keeps a file updated whenever an inventory
is successfully sent. This can be used to set up a monitor on
the node, that will check the age of the file not older then
a certain threshold.