### PR TITLE
Fixes #7094 Multi-Line ENV variables parsing fixed

### DIFF
--- a/techniques/system/common/1.0/environment-variables.st
+++ b/techniques/system/common/1.0/environment-variables.st
@@ -30,12 +30,16 @@ bundle agent get_environment_variables
       "script" string => "#! /bin/sh
 env | sed 's/=/]=/' |sed 's/^/=node.env[/'";
 
+    !windows.linux::
+      "env_vars" slist => splitstring( execresult("(${paths.printf} '\0'; ${paths.env} -0) | ${paths.grep} -aoP '\x00([^=]+)' | ${paths.tr} -d '\000' | ${paths.tr} '\n' ',' | ${paths.sed} 's/,$//'","useshell"), "," , 2000);
+      "node.env[${env_vars}]" string => getenv( "${env_vars}", 5000);
+
     windows::
      "script" string => "@echo off
 for /F  \"tokens=1,2* delims==\" %%G IN ('SET') DO ECHO =node.env[%%G]=%%H";
 
   files:
-    !windows::
+    !windows.!linux::
       "${sys.workdir}/modules/env"
         create        => "true",
         perms         => mog("755", "root", "0"),
@@ -50,7 +54,7 @@ for /F  \"tokens=1,2* delims==\" %%G IN ('SET') DO ECHO =node.env[%%G]=%%H";
 
 
   commands:
-    !windows::
+    !windows.!linux::
       "${sys.workdir}/modules/env"
         module => "true";
     windows::


### PR DESCRIPTION
 Not using 'command module' to enumerate env variables, as multi-line
strings are not well supported. First we get the env variable's names,
then read their values by a cfengine built-in getenv command.
 Will not work on Solaris/AIX, as their env does not support the -0
option, to output it null-terminated.