### PR TITLE
Fixes #7464: svcadm does not exist - so syslog is never restarted on Solaris

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -562,7 +562,7 @@ bundle agent check_log_system
   commands:
 
     solaris.(syslog_ng_repaired|rsyslog_repaired|syslogd_repaired)::
-      "${paths.path[svcadm]} refresh svc:/system/system-log:default";
+      "${paths.svcadm} refresh svc:/system/system-log:default";
 
     aix.syslogd_repaired::
       "/usr/bin/refresh -s syslogd";


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7464