### PR TITLE
Fixes #7389: Syslog fails to restart due bad line in syslog-ng.conf

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -753,7 +753,7 @@ bundle edit_line edit_syslog_conf_file(line_to_add, pattern_to_remove)
   delete_lines:
       "${pattern_to_remove}";
       "\$\(syslog_ng_conf\)";
-
+      "\$\{syslog_ng_conf\}";
 
   insert_lines:
       "${line_to_add}"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7389