### PR TITLE
As per bash man:

### DIFF
--- a/techniques/system/common/1.0/environment-variables.st
+++ b/techniques/system/common/1.0/environment-variables.st
@@ -27,7 +27,8 @@ bundle agent get_environment_variables
     # will be available using the syntax ${node.env[ENV_NAME]}
 
     !windows::
-      "script" string => "#! /bin/sh
+      "script" string => "#!/bin/sh
+source /etc/profile
 env | sed 's/=/]=/' |sed 's/^/=node.env[/'";
 
     !windows.linux::


### PR DESCRIPTION
  /etc/profile
  The systemwide initialization file, executed for login shells

Problem is that cf-agent seems to not fully have environment variables as not being in a login shell.
Not sure how this translate on a plain /bin/sh - not symlinked to /bin/bash - nor if it's standardized across distributions.