### PR TITLE
Fixes #7496: rudder-techniques test script \"technique-files\" doesn't list promises.cf and failsafe.cf in initial-promises

### DIFF
--- a/scripts/technique-files
+++ b/scripts/technique-files
@@ -17,12 +17,13 @@ set -euo pipefail
 LAST=0
 HELP=0
 DIR_ONLY=0
+INCLUDE_INITIAL=0
 PATTERN=""
 FILTER=""
 PLACEHOLDER=1
 
 # parameter parsing
-while getopts "hldf:s:p" opt
+while getopts "hldif:s:p" opt
 do
   case ${opt} in
     h)
@@ -33,6 +34,9 @@ do
       ;;
     d)
       DIR_ONLY=1
+      ;;
+    i)
+      INCLUDE_INITIAL=1
       ;;
     f)
       [ -n "${PATTERN}" ] && PATTERN="${PATTERN} -o "
@@ -59,13 +63,14 @@ shift $((OPTIND-1))
 # usage
 if [ ${HELP} -eq 1 -o $# -eq 0 ]
 then
-  echo "Usage $0 [-l] [-d] [-f <pattern> [-f <pattern>] ...] <technique directory> [<technique directory> ...]"
+  echo "Usage $0 [-p] [-l] [-d] [-i] [-f <pattern> [-f <pattern>] ...] <technique directory> [<technique directory> ...]"
   echo "  Find and filter files or directories for techniques under a specified directory"
   echo ""
   echo "  <technique directory> : specify the root of technique directories"
   echo "  -p : force including placeholder versions (default is to ignore them)"
   echo "  -l : list last version of each technique only"
   echo "  -d : list only base directories of techniques"
+  echo "  -i : list 'special' files in initial-promises root (promises.cf, failsafe.cf, ...)"
   echo "  -f <pattern> : list files matching a pattern (may be repeated for multiple patterns)"
   echo "  -s '<command line>' : command to filter results, {} will be replaced by the file name"
   echo "     example : $0 -d -f '*.cf' -s 'grep edit_line {}' techniques"
@@ -96,6 +101,13 @@ find_directories() {
       fi
 }
 
+# find extra 'special' files in initial-promises root (promises.cf, failsafe.cf, ...)
+find_initial() {
+  if [ ${INCLUDE_INITIAL} -eq 1 ]; then
+    find "${directory}" -not -wholename "*/.git/*" -type d -name "node-server" |
+      xargs -r -n1 -I{} find "{}" -maxdepth 1 -not -wholename "*/.git/*" -type f
+  fi
+}
 
 # main script
 for directory in "$@"
@@ -114,7 +126,7 @@ do
       find $(find_directories) -type f ${PATTERN} -exec /bin/bash -c "${FILTER} > /dev/null && echo {}" \; | xargs -r -n1 dirname | sort -u
     else
       # filter and show all file names
-      find $(find_directories) -type f ${PATTERN} -exec /bin/bash -c "${FILTER} > /dev/null && echo {}" \; | sort -u
+      find $(find_directories) $(find_initial) -type f ${PATTERN} -exec /bin/bash -c "${FILTER} > /dev/null && echo {}" \; | sort -u
     fi
   else
     if [ ${DIR_ONLY} -eq 1 ]
@@ -123,7 +135,7 @@ do
       find_directories
     else
       # list files within directories
-      find $(find_directories) -type f ${PATTERN}
+      find $(find_directories) $(find_initial) -type f ${PATTERN}
     fi
   fi
 done


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7496