### PR TITLE
Fixes #7499: Use of nonexistant class cfengine_community makes failsafe.cf not copy CFEngine binaries to /var/rudder

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -129,7 +129,7 @@ bundle agent init_files
       "missing_key" not => fileexists("${sys.workdir}/ppkeys/localhost.priv");
 
   files:
-    cfengine_community.!windows::
+    community_edition.!windows::
       "${sys.workdir}/bin/${components}"
         perms => u_p("700"),
         copy_from => cp("${cfengine_install_path}/bin/${components}","localhost"),

--- a/scripts/check-techniques.sh
+++ b/scripts/check-techniques.sh
@@ -110,6 +110,16 @@ do
   fi
 done
 
+# Check that we are not using the non-existant class cfengine_community (which does not exist)
+find ${REPOSITORY_PATH} -type f -name "*.st" -or -name "*.cf" | while read filename
+do
+  if grep -q 'cfengine_community' "${filename}"; then
+    echo "Found invalid use of class cfengine_community that does not exists in file ${filename}. Use community_edition instead."
+    exit 8
+  fi
+done
+
+
 # Check that techniques are written in normal ordering
 ${REPOSITORY_PATH}/scripts/technique-files -l -f '*.cf' -f '*.st' "${REPOSITORY_PATH}" | grep -v cfengine_stdlib | xargs ${REPOSITORY_PATH}/scripts/ordering.pl || exit 9
 

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -128,7 +128,7 @@ bundle agent init_files
       "missing_key" not => fileexists("${sys.workdir}/ppkeys/localhost.priv");
 
   files:
-    cfengine_community.!windows::
+    community_edition.!windows::
       "${sys.workdir}/bin/${components}"
         perms     => u_p("700"),
         copy_from => cp("${cfengine_install_path}/bin/${components}","localhost"),


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7499