### PR TITLE
Fixes #7506: \"MOTD configuration\" technique still uses \"root\" group, therefore breaking on non-Linux OSes

### DIFF
--- a/techniques/systemSettings/systemManagement/motdConfiguration/3.0/main.st
+++ b/techniques/systemSettings/systemManagement/motdConfiguration/3.0/main.st
@@ -35,7 +35,7 @@ bundle agent rudder_motd_configuration(class_prefix, service_name, trackingkey, 
     aix::
       "rudder_motd_group"       string => "bin";
     !aix::
-      "rudder_motd_group"       string => "root";
+      "rudder_motd_group"       string => "0";
 
   classes:
       "rudder_motd_absent"         not => fileexists("/etc/motd");


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7506