### PR TITLE
Fixes #7501: Technique \"Clock settings\" uses Europe/Paris as China's timezone (technique version 3.0)

### DIFF
--- a/techniques/systemSettings/misc/clockConfiguration/3.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/3.0/clockConfiguration.st
@@ -118,7 +118,7 @@ bundle agent check_clock_configuration
 
     clock_set_beijing::
 
-      "linux_timezone" string => "Europe/Paris";
+      "linux_timezone" string => "Asia/Shanghai";
       "windows_timezone" string => "China Standard Time";
 
   classes:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7501