### PR TITLE
Fixes #7624: Technique copyGitFile can send success AND error reports on post-hook execution and lead to unexpected reports

### DIFF
--- a/techniques/fileDistribution/copyGitFile/1.3/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.3/copyFileFromSharedFolder.st
@@ -110,13 +110,13 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} was already in the desired state, so no command was executed"
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_modified";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_modified.copy_file_${index}_kept";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} was correctly executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.copyfile_posthook_${index}_command_run_ok";
 
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "@@copyFile@@result_error@@$(copyfile[$(index)][uuid])@@Post-modification hook@@$(copyfile[$(index)][name])@@$(g.execRun)##$(g.uuid)@#$(copyfile[$(index)][destination]) couldn't be copied, so the post-hook command is not executed"

--- a/techniques/fileDistribution/copyGitFile/1.4/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.4/copyFileFromSharedFolder.st
@@ -142,13 +142,13 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} was already in the desired state, so no command was executed"
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_modified";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_modified.copy_file_${index}_kept";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} was correctly executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.copyfile_posthook_${index}_command_run_ok";
 
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "@@copyFile@@result_error@@$(copyfile[$(index)][uuid])@@Post-modification hook@@$(copyfile[$(index)][name])@@$(g.execRun)##$(g.uuid)@#$(copyfile[$(index)][destination]) couldn't be copied, so the post-hook command is not executed"

--- a/techniques/fileDistribution/copyGitFile/1.5/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.5/copyFileFromSharedFolder.st
@@ -181,15 +181,15 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} was already in the desired state, so no command was executed"
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_modified";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_modified.copy_file_${index}_kept";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} was correctly executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.copyfile_posthook_${index}_command_run_ok";
 
-      "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+      "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} failed"
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "@@copyFile@@result_error@@$(copyfile[$(index)][uuid])@@Post-modification hook@@$(copyfile[$(index)][name])@@$(g.execRun)##$(g.uuid)@#$(copyfile[$(index)][destination]) couldn't be copied, so the post-hook command is not executed"
-        ifvarclass => "execute_command_$(index).copy_file_$(index)_failed";
+        ifvarclass => "execute_command_${index}.copy_file_${index}_failed";
 }

--- a/techniques/fileDistribution/copyGitFile/1.6/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.6/copyFileFromSharedFolder.st
@@ -203,13 +203,13 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} was already in the desired state, so no command was executed"
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_repaired";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_repaired.copy_file_${index}_kept";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} was correctly executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.copyfile_posthook_${index}_command_run_ok";
 
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} couldn't be copied, so the post-hook command is not executed"

--- a/techniques/fileDistribution/copyGitFile/1.7/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/1.7/copyFileFromSharedFolder.st
@@ -207,13 +207,13 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} was already in the desired state, so no command was executed"
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_repaired";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_repaired.copy_file_${index}_kept";
 
       "@@copyFile@@result_success@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} was correctly executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.copyfile_posthook_${index}_command_run_ok";
 
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "@@copyFile@@result_error@@${copyfile[${index}][uuid]}@@Post-modification hook@@${copyfile[${index}][name]}@@${g.execRun}##${g.uuid}@#${copyfile[${index}][destination]} couldn't be copied, so the post-hook command is not executed"

--- a/techniques/fileDistribution/copyGitFile/2.1/copyFileFromSharedFolder.st
+++ b/techniques/fileDistribution/copyGitFile/2.1/copyFileFromSharedFolder.st
@@ -216,13 +216,13 @@ bundle agent download_from_shared_folder
         ifvarclass => "!execute_command_${index}";
 
       "any" usebundle => rudder_common_report("copyFile", "result_success", "${copyfile[${index}][uuid]}", "Post-modification hook", "${copyfile[${index}][name]}", "${copyfile[${index}][destination]} was already in the desired state, so no command was executed"),
-        ifvarclass => "execute_command_${index}.copy_file_${index}_kept.!copy_file_${index}_repaired";
+        ifvarclass => "execute_command_${index}.!copy_file_${index}_failed.!copy_file_${index}_repaired.copy_file_${index}_kept";
 
       "any" usebundle => rudder_common_report("copyFile", "result_success", "${copyfile[${index}][uuid]}", "Post-modification hook", "${copyfile[${index}][name]}", "The post-hook command for ${copyfile[${index}][destination]} was correctly executed"),
-        ifvarclass => "copyfile_posthook_${index}_command_run_ok";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_ok";
 
       "any" usebundle => rudder_common_report("copyFile", "result_error", "${copyfile[${index}][uuid]}", "Post-modification hook", "${copyfile[${index}][name]}", "The post-hook command for ${copyfile[${index}][destination]} couldn't be executed"),
-        ifvarclass => "copyfile_posthook_${index}_command_run_failed";
+        ifvarclass => "execute_command_${index}.copyfile_posthook_${index}_command_run_failed";
 
       # A copy_from + perms could result in any combinaision of success/repaired/failed, so we have to cover the failed.modified which results in no copy
       "any" usebundle => rudder_common_report("copyFile", "result_error", "${copyfile[${index}][uuid]}", "Post-modification hook", "${copyfile[${index}][name]}", "${copyfile[${index}][destination]} couldn't be copied, so the post-hook command is not executed"),


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7624