### PR TITLE
Fixes #7869: Add a default value for COPYFILE_STICKY_FOLDER for copyGitFile 2.1

### DIFF
--- a/techniques/fileDistribution/copyGitFile/2.1/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/2.1/metadata.xml
@@ -199,6 +199,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <LONGDESCRIPTION>If set, and the path is a folder, and recursion is set to "The whole content of the folder", apply on the whole folder (won't apply to subfolders, for obvious security reasons).</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>boolean</TYPE>
+          <DEFAULT>false</DEFAULT>
         </CONSTRAINT>
       </INPUT>
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7869