### PR TITLE
Fixes #7955: Technique \"Download a file from the shared folder\" is missing a default value for permissions in version 2.0

### DIFF
--- a/techniques/fileDistribution/copyGitFile/2.0/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/2.0/metadata.xml
@@ -175,6 +175,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <DESCRIPTION>Permissions to apply on the file</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>perm</TYPE>
+          <DEFAULT>644</DEFAULT>
         </CONSTRAINT>
       </INPUT>
       <INPUT>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7955