### PR TITLE
Fixes #7978: Missing \"don't change\" password hash type in userManagement 6.0

### DIFF
--- a/techniques/systemSettings/userManagement/userManagement/6.0/metadata.xml
+++ b/techniques/systemSettings/userManagement/userManagement/6.0/metadata.xml
@@ -142,7 +142,7 @@ It is intended to check the user parameters on the target host.
           <CONSTRAINT>
             <MAYBEEMPTY>true</MAYBEEMPTY>
             <TYPE>password</TYPE>
-            <PASSWORDHASH>linux-shadow-md5,linux-shadow-sha256,linux-shadow-sha512</PASSWORDHASH> 
+            <PASSWORDHASH>linux-shadow-md5,linux-shadow-sha256,linux-shadow-sha512,plain</PASSWORDHASH> 
           </CONSTRAINT>
         </INPUT>
       </SECTION>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7978