### PR TITLE
Fixes #7985: gzip can stop rudder agent when compressing log files

### DIFF
--- a/techniques/system/server-roles/1.0/compress-webapp-log.st
+++ b/techniques/system/server-roles/1.0/compress-webapp-log.st
@@ -28,6 +28,6 @@ bundle agent compress_webapp_log
     "/var/log/rudder/webapp"
       file_select => date_pattern("${log_compress_delay}", "@{logs_patern}"),
       depth_search => recurse("0"),
-      transformer => "${g.gzip} \"${this.promiser}\"";
+      transformer => "${g.gzip} -f \"${this.promiser}\"";
 
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7985