### PR TITLE
Fixes #7994:  \"Download a file from shared folder\" technique doesn't have an explicit default value for \"Compare method\" (was mtime, now digest) - 3.0 branch

### DIFF
--- a/techniques/fileDistribution/copyGitFile/2.0/metadata.xml
+++ b/techniques/fileDistribution/copyGitFile/2.0/metadata.xml
@@ -154,6 +154,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <VALUE>exists</VALUE>
           <LABEL>exists</LABEL>
         </ITEM>
+        <CONSTRAINT>
+          <DEFAULT>digest</DEFAULT>
+        </CONSTRAINT>
       </SELECT1>
 
       <INPUT>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7994