### PR TITLE
Fixes #8145: node config id is not defined any more on windows and android

### DIFF
--- a/techniques/system/common/1.0/site.st
+++ b/techniques/system/common/1.0/site.st
@@ -127,6 +127,7 @@ bundle common g
       # We would like to use date's "--rfc-3339=second" option here, but it is not available on older OSes (RHEL 3/4, AIX 5...)
       "execRun"                    string => execresult("/bin/date -u \"+%Y-%m-%d %T+00:00\"", "noshell");
 
+    any::
       # Heartbeat interval, in minutes. Only used when in "changes-only" compliance mode
       # In this mode, we should only send a "StartRun"/"EndRun" message pair if changes occur,
       # or if this interval has elapsed since we last sent one


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8145