### PR TITLE
Fixes #8189:  It is not possible to define value with \" in generic variable definition (branch 3.0 and more)

### DIFF
--- a/techniques/systemSettings/misc/genericVariableDefinition/2.0/metadata.xml
+++ b/techniques/systemSettings/misc/genericVariableDefinition/2.0/metadata.xml
@@ -52,7 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <DESCRIPTION>Variable content</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>string</TYPE>
-          <REGEX error="Please enter a valid CFengine variable content"><![CDATA[ [^"]*[^"\\] ]]></REGEX>
           <MAYBEEMPTY>true</MAYBEEMPTY>
         </CONSTRAINT>
       </INPUT>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8189