### PR TITLE
Fixes #8208: check_cron_daemon conflicts with cronManagement

### DIFF
--- a/techniques/systemSettings/systemManagement/cronManagement/3.0/cronConfiguration.st
+++ b/techniques/systemSettings/systemManagement/cronManagement/3.0/cronConfiguration.st
@@ -110,10 +110,10 @@ bundle agent check_cron_configuration
     pass3.!cron_restart::
       "any" usebundle => rudder_common_report("cronConfiguration", "result_success", "${cron_uuid[${cron_index}]}", "Cron process", "None", "The cron process is running. Skipping...");
 
-    pass3.(service_restart_cron_ok|service_restart_crond_ok)::
+    pass3.cron_restart.(service_restart_cron_ok|service_restart_crond_ok)::
       "any" usebundle => rudder_common_report("cronConfiguration", "result_repaired", "${cron_uuid[${cron_index}]}", "Cron process", "None", "The cron process has been restarted");
 
-    pass3.(service_restart_cron_not_ok|service_restart_crond_not_ok)::
+    pass3.cron_restart.(service_restart_cron_not_ok|service_restart_crond_not_ok)::
       "any" usebundle => rudder_common_report("cronConfiguration", "result_success", "${cron_uuid[${cron_index}]}", "Cron process", "None", "Could not restart the cron process!");
 
     pass3.(!windows.cron_absent)::


### PR DESCRIPTION
Make sure cronManagement's reports are only triggered when its local
class has determined the need to restart the service, and not a fake
class from check_cron_daemon