### PR TITLE
Fixes #8307: Use variables for path to cf-agent in system Techniques to work on Windows

### DIFF
--- a/initial-promises/node-server/common/1.0/cf-served.cf
+++ b/initial-promises/node-server/common/1.0/cf-served.cf
@@ -60,7 +60,7 @@ bundle server access_rules
 
     any::
       # Allow server to remotely run the agent
-      "/var/rudder/cfengine-community/bin/cf-agent"
+      "${sys.cf_agent}"
         admit   => { host2ip("${server_info.cfserved}"), string_downcase(escape("${server_info.cfserved}")) };
 
   roles:

--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -83,7 +83,7 @@ bundle server access_rules
 &endif&
     policy_server_set::
       # Allow server to remotely run the agent
-      "${sys.workdir}/bin/cf-agent"
+      "${sys.cf_agent}"
         admit   => { host2ip("${server_info.cfserved}"), string_downcase(escape("${server_info.cfserved}")) };
 
   roles:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8307