### PR TITLE
Fixes #8045: Using Rudder server 3.x + rudder agent 2.11.x, a node doesn't properly detect its change of relay server

### DIFF
--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -90,6 +90,11 @@ bundle agent doInventory
       "pass2" expression => "pass1";
       "pass1" expression => "any";
 
+  files:
+    # Clean policy server uuid file defined in 2.11 or earlier version, as location in 3.0+ is ${sys.workdir}/rudder-server-uuid.txt
+    "${g.rudder_var_tmp}/uuid.txt"
+      delete => tidy;
+
   methods:
       # Compute the inventory time
       "any" usebundle => computeInventoryTime;


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8045