### PR TITLE
Fixes #8336: Error on windows: agent tries to check if /usr/bin/env supports the -0 option

### DIFF
--- a/techniques/system/common/1.0/environment-variables.st
+++ b/techniques/system/common/1.0/environment-variables.st
@@ -45,6 +45,7 @@ env | sed 's/=/]=/' |sed 's/^/=node.env[/'";
 for /F  \"tokens=1,2* delims==\" %%G IN ('SET') DO ECHO =node.env[%%G]=%%H";
 
   classes:
+    !windows::
       # Test if the platform supports env -0 option
       # If it does not, multiline environment variables require different handling, that is a little less reliable
       "supports_env_0" expression => returnszero("${paths.env} -0 >/dev/null 2>/dev/null","useshell");


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8336