### PR TITLE
Fixes #8385: Load environment variables from /etc/profile  - escape ampersands

### DIFF
--- a/techniques/system/common/1.0/environment-variables.st
+++ b/techniques/system/common/1.0/environment-variables.st
@@ -28,7 +28,7 @@ bundle agent get_environment_variables
 
     !windows::
       "script" string => "#!/bin/sh
-[ -f /etc/profile ] && . /etc/profile
+[ -f /etc/profile ] \&\& . /etc/profile
 env | sed 's/=/]=/' |sed 's/^/=node.env[/'";
 
     !windows.linux.supports_env_0::


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8385