### PR TITLE
Fixes #8389: Merge rudder_lib from initial promises and system technique - adapt failsafe.cf for new rudder-stdlib-core.cf name

### DIFF
--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -24,7 +24,7 @@ body common control
 {
         bundlesequence     => { "init_files", "update" };
 
-        inputs             => { "common/1.0/update.cf", "common/1.0/rudder_stdlib_core.cf" };
+        inputs             => { "common/1.0/update.cf", "common/1.0/rudder-stdlib-core.cf" };
         output_prefix      => "rudder";
         
         protocol_version   => "classic";

--- a/techniques/system/common/1.0/rudder-stdlib-core.st
+++ b/techniques/system/common/1.0/rudder-stdlib-core.st
@@ -20,7 +20,7 @@
 #
 # This library includes standardized bundles and bodies to be used as part of the
 # "best practices" in the Techniques writing, for classes and reporting only.
-# Other bodies and bundles should be included in rudder_stdlib.st
+# Other bodies and bundles should be included in rudder-stdlib.st
 #
 
 ##################################################


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8389