### PR TITLE
Fixes #8421: Invalidation of previous package state and of package status cache does not work on rpmPackageInstallation 5.0 5.1 6.0 6.1 7.0

### DIFF
--- a/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
@@ -49,31 +49,16 @@ bundle agent check_rpm_package_installation {
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
     rudder_promises_generated_repaired::
+      "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
-      "unpersist_rpm_kept_classes_${index_rpmpkg}"
+      "unpersist_rpm_classes_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_kept_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_kept_classes_purged_${index_rpmpkg}"
+      "rpm_classes_purged_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_kept_${index_rpmpkg}");
-
-      "unpersist_rpm_repaired_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_installed_${index_rpmpkg}", "1");
-
-      "rpm_repaired_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_installed_${index_rpmpkg}");
-
-      "unpersist_rpm_error_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_failed_${index_rpmpkg}", "1");
-
-      "rpm_error_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_failed_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}");
 
       "unpersist_${zmd_classes_to_cancel_on_update}"
         string  => "undefine",

--- a/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
@@ -49,31 +49,16 @@ bundle agent check_rpm_package_installation {
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
     rudder_promises_generated_repaired::
+      "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
-      "unpersist_rpm_kept_classes_${index_rpmpkg}"
+      "unpersist_rpm_classes_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_kept_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_kept_classes_purged_${index_rpmpkg}"
+      "rpm_classes_purged_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_kept_${index_rpmpkg}");
-
-      "unpersist_rpm_repaired_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_installed_${index_rpmpkg}", "1");
-
-      "rpm_repaired_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_installed_${index_rpmpkg}");
-
-      "unpersist_rpm_error_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_failed_${index_rpmpkg}", "1");
-
-      "rpm_error_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_failed_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}");
 
       "unpersist_${zmd_classes_to_cancel_on_update}"
         string  => "undefine",

--- a/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
@@ -49,31 +49,16 @@ bundle agent check_rpm_package_installation {
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
     rudder_promises_generated_repaired::
+      "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
-      "unpersist_rpm_kept_classes_${index_rpmpkg}"
+      "unpersist_rpm_classes_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_kept_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_kept_classes_purged_${index_rpmpkg}"
+      "rpm_classes_purged_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_kept_${index_rpmpkg}");
-
-      "unpersist_rpm_repaired_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_installed_${index_rpmpkg}", "1");
-
-      "rpm_repaired_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_installed_${index_rpmpkg}");
-
-      "unpersist_rpm_error_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_failed_${index_rpmpkg}", "1");
-
-      "rpm_error_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_failed_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}");
 
       "unpersist_${zmd_classes_to_cancel_on_update}"
         string  => "undefine",

--- a/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
@@ -56,31 +56,16 @@ bundle agent check_rpm_package_installation {
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
     rudder_promises_generated_repaired::
+      "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
-      "unpersist_rpm_kept_classes_${index_rpmpkg}"
+      "unpersist_rpm_classes_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_kept_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_kept_classes_purged_${index_rpmpkg}"
+      "rpm_classes_purged_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_kept_${index_rpmpkg}");
-
-      "unpersist_rpm_repaired_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_installed_${index_rpmpkg}", "1");
-
-      "rpm_repaired_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_installed_${index_rpmpkg}");
-
-      "unpersist_rpm_error_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_failed_${index_rpmpkg}", "1");
-
-      "rpm_error_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_failed_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}");
 
       "unpersist_${zmd_classes_to_cancel_on_update}"
         string  => "undefine",

--- a/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
@@ -59,31 +59,24 @@ bundle agent check_rpm_package_installation {
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
     rudder_promises_generated_repaired::
+      "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
-      "unpersist_rpm_kept_classes_${index_rpmpkg}"
+      "unpersist_available_packages_classes_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_kept_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_updated_available_packages_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_kept_classes_purged_${index_rpmpkg}"
+      "available_packages_classes_purged_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_kept_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_updated_available_packages_${package_classes_to_cancel_suffix}");
 
-      "unpersist_rpm_repaired_classes_${index_rpmpkg}"
+      "unpersist_rpm_classes_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_installed_${index_rpmpkg}", "1");
+        classes => rudder_always_classes_persist("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}", "1");
 
-      "rpm_repaired_classes_purged_${index_rpmpkg}"
+      "rpm_classes_purged_${index_rpmpkg}_${package_classes_to_cancel_suffix}"
         string  => "undefine",
-        classes => cancel_all_classes("rpm_package_installed_${index_rpmpkg}");
-
-      "unpersist_rpm_error_classes_${index_rpmpkg}"
-        string  => "undefine",
-        classes => rudder_always_classes_persist("rpm_package_install_failed_${index_rpmpkg}", "1");
-
-      "rpm_error_classes_purged_${index_rpmpkg}"
-        string  => "undefine",
-        classes => cancel_all_classes("rpm_package_install_failed_${index_rpmpkg}");
+        classes => cancel_all_classes("rpm_package_installation_${index_rpmpkg}_${package_classes_to_cancel_suffix}");
 
       "unpersist_${zmd_classes_to_cancel_on_update}"
         string  => "undefine",


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8421