### PR TITLE
Fixes #8425: Invalidation of previous package state and of package status cache does not work on rpmPackageInstallation 5.0 5.1 6.0 6.1 7.0 - fix so only the first pass resets classes

### DIFF
--- a/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
@@ -48,7 +48,7 @@ bundle agent check_rpm_package_installation {
     # If the promises have been updated, we need to remove previously
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
-    rudder_promises_generated_repaired::
+    rudder_promises_generated_repaired.!pass1.!pass2.!pass3::
       "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
@@ -71,6 +71,12 @@ bundle agent check_rpm_package_installation {
 	classes:
 
 		"$(index_rpmpkg)_package_version_defined" not => strcmp("$(rpm_data[$(index_rpmpkg)][1])", "default");
+
+    any::
+
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
 
 	processes:
 

--- a/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
@@ -48,7 +48,7 @@ bundle agent check_rpm_package_installation {
     # If the promises have been updated, we need to remove previously
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
-    rudder_promises_generated_repaired::
+    rudder_promises_generated_repaired.!pass1.!pass2.!pass3::
       "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
@@ -71,6 +71,12 @@ bundle agent check_rpm_package_installation {
 	classes:
 
 		"$(index_rpmpkg)_package_version_defined" not => strcmp("$(rpm_data[$(index_rpmpkg)][1])", "default");
+
+    any::
+
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
 
 	processes:
 

--- a/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
@@ -48,7 +48,7 @@ bundle agent check_rpm_package_installation {
     # If the promises have been updated, we need to remove previously
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
-    rudder_promises_generated_repaired::
+    rudder_promises_generated_repaired.!pass1.!pass2.!pass3::
       "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
@@ -71,6 +71,12 @@ bundle agent check_rpm_package_installation {
 	classes:
 
 		"${index_rpmpkg}_package_version_defined" not => strcmp("${rpm_data[${index_rpmpkg}][1]}", "default");
+
+    any::
+
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
 
 	packages:
 

--- a/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
@@ -55,7 +55,7 @@ bundle agent check_rpm_package_installation {
     # If the promises have been updated, we need to remove previously
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
-    rudder_promises_generated_repaired::
+    rudder_promises_generated_repaired.!pass1.!pass2.!pass3::
       "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 
@@ -103,6 +103,12 @@ bundle agent check_rpm_package_installation {
       "${index_rpmpkg}_package_version_defined" not => strcmp("${rpm_data[${index_rpmpkg}][1]}", "default");
 
       "first_pass" expression => "any";
+
+    any::
+
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
 
   packages:
     redhat|SuSE::

--- a/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
@@ -58,7 +58,7 @@ bundle agent check_rpm_package_installation {
     # If the promises have been updated, we need to remove previously
     # defined persistent classes (by setting there persistence to 1 minutes)
     # and cancelling also the classes for this run
-    rudder_promises_generated_repaired::
+    rudder_promises_generated_repaired.!pass1.!pass2.!pass3::
       "package_classes_to_cancel_suffix" slist => { "kept", "repaired", "error", "failed", "denied", "timeout" }; # all classes set by rudder_common_classes_persist body
       "zmd_classes_to_cancel_on_update" slist => { "zmd_kept", "zmd_restarted", "could_not_restart_zmd" };
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8425