### PR TITLE
Fixes #8451: On Centos6.6, rsyslog is always restarted

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -454,11 +454,11 @@ bundle agent check_log_system
 
       "syslog_ng_source" string => "s_sys";
 
-    rsyslogd.rsyslog_version_ok::
+    rsyslogd.rsyslog_version_5_6_4_ok::
 
       "rsyslogd_message_reduction" string => "$RepeatedMsgReduction off${const.n}";
       
-    rsyslogd.rsyslog_version_not_ok::
+    rsyslogd.rsyslog_version_5_6_4_not_ok::
 
       "rsyslogd_message_reduction" string => "";
 
@@ -492,7 +492,7 @@ bundle agent check_log_system
         comment => "Add the rsyslog.conf.d include if not already present",
         classes => kept_if_else("rsyslog_kept", "rsyslog_repaired" , "rsyslog_failed");
 
-    !windows.rsyslogd.!policy_server::
+    (rsyslog_version_5_6_4_ok|rsyslog_version_5_6_4_not_ok).!windows.rsyslogd.!policy_server::
       "/etc/rsyslog.d/rudder-agent.conf"
         edit_line => append_if_no_lines("#Rudder log system${const.n}${rsyslogd_message_reduction}${const.n}if $syslogfacility-text == 'local6' and $programname startswith 'rudder' then @@${server_info.cfserved}:&SYSLOGPORT&${const.n}if $syslogfacility-text == 'local6' and $programname startswith 'rudder' then ~"),
         create => "true",
@@ -604,7 +604,7 @@ bundle agent check_rsyslog_version {
       "rsyslogd" expression => fileexists("/etc/rsyslog.conf");
 
   files:
-    rsyslogd.rsyslog_version_ok::
+    rsyslogd.rsyslog_version_5_7_1_ok::
       "/etc/rsyslog.d/remove_limit.conf"
         edit_line => append_if_no_lines("$SystemLogRateLimitInterval 0"),
         edit_defaults => noempty_backup,

--- a/tools/check-rsyslog-version
+++ b/tools/check-rsyslog-version
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-# The minimal rsyslog version we support is 5.7.1.
-# This utility checks if this condition is met and
-# returns the appropriate CFEngine class using the
-# module protocol
+# This script allows testing for a minimal rsyslog
+# version and define matching classes using
+# the module protocol.
 
 # rpmvercmp location
 RPMVERCMP="/var/rudder/cfengine-community/bin/rpmvercmp"
@@ -15,14 +14,16 @@ else
   MINIMAL_RSYSLOG_VERSION="5.7.1"
 fi
 
+CANONIFIED_VERSION=$(echo ${MINIMAL_RSYSLOG_VERSION} | sed 's/\./_/g')
+
 if type rsyslogd >/dev/null 2>&1; then
 
   CURRENT_RSYSLOG_VERSION=$(rsyslogd -v | head -n1 | sed "s/^rsyslogd \\([^, ]*\\).*$/\\1/")
 
   if ${RPMVERCMP} ${CURRENT_RSYSLOG_VERSION} lt ${MINIMAL_RSYSLOG_VERSION}; then
-    echo "+rsyslog_version_not_ok"
+    echo "+rsyslog_version_${CANONIFIED_VERSION}_not_ok"
   else
-    echo "+rsyslog_version_ok"
+    echo "+rsyslog_version_${CANONIFIED_VERSION}_ok"
   fi
 
 else


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8451