### PR TITLE
Fixes #8458: If using Rudder Server 3.1 and a node with agent 3.2, protocol used is TLS

### DIFF
--- a/initial-promises/node-server/failsafe.cf
+++ b/initial-promises/node-server/failsafe.cf
@@ -28,6 +28,7 @@ body common control
         inputs => { "common/1.0/update.cf" };
         output_prefix => "rudder";
 
+        protocol_version   => "classic";
 }
 
 body agent control {

--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -47,6 +47,8 @@ body common control
     any::
         output_prefix => "rudder";
 
+        protocol_version   => "classic";
+
         inputs => {
   @{va.inputs_list}
     };

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/failsafe.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/failsafe.cf
@@ -26,6 +26,8 @@ body common control
         bundlesequence => { "init_files", "update" };
 
         inputs => { "common/update.cf" };
+
+        protocol_version   => "classic";
 }
 
 bundle common g

--- a/initial-promises/rootServerInitialPromises/cfengine-nova/promises.cf
+++ b/initial-promises/rootServerInitialPromises/cfengine-nova/promises.cf
@@ -32,6 +32,7 @@ body common control
 
         output_prefix => "rudder";
 
+        protocol_version   => "classic";
 }
 
 bundle common va

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -26,6 +26,8 @@ body common control
 
         inputs             => { "common/1.0/update.cf", "common/1.0/rudder_stdlib_core.cf" };
         output_prefix      => "rudder";
+
+        protocol_version   => "classic";
 }
 
 body agent control {

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -27,6 +27,8 @@ body common control
     any::
         output_prefix => "rudder";
 
+        protocol_version   => "classic";
+
         inputs => {
           @{va.ncf_inputs},
           &INPUTLIST&


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8458