### PR TITLE
Fixes #8557: Support running cfengine enterprise on debug port

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -220,7 +220,7 @@ body runagent control
 
     community_edition.!debug_port::
         port => "&COMMUNITYPORT&";
-    community_edition.debug_port::
+    debug_port::
         port => "5310";
 }
 &endif&


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8557