### PR TITLE
Fixes #8738: Fix metadata syntax of generic enforce file content

### DIFF
--- a/techniques/fileDistribution/checkGenericFileContent/7.0/tests/simple_content_replace.metadata
+++ b/techniques/fileDistribution/checkGenericFileContent/7.0/tests/simple_content_replace.metadata
@@ -1,5 +1,5 @@
 {
-  "init": "simple_content_replace.cf"
+  "init": "simple_content_replace.cf",
   "directive": "simple_content_replace.json",
   "check": "simple_content_replace.rb", 
   "compliance": 100


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8738