### PR TITLE
Fixes #8824: Zypper repo management "Delete all other repositories than those managed by Rudder" is broken

### DIFF
--- a/techniques/applications/zypperPackageManagerRepositories/1.0/zypper-repositories-management.st
+++ b/techniques/applications/zypperPackageManagerRepositories/1.0/zypper-repositories-management.st
@@ -64,7 +64,7 @@ bundle agent zypper_repositories_management
 
     SuSE.zypper_disable_other_repositories::
 
-      "/etc/zypp/repos.d/.*"
+      "/etc/zypp/repos.d/"
         delete       => tidy,
         file_select  => ex_list("@{zypper_files}"),
         depth_search => recurse("inf"),


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8824