### PR TITLE
Fixes #8750: outputs folder is cleaned at each run

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -446,7 +446,8 @@ bundle agent garbage_collection
 
         delete => tidy,
         file_select => days_old("7"),
-        depth_search => recurse("inf");
+        depth_search => recurse("inf"),
+        ifelapsed => "1440"; # 24h
 
       "${g.rudder_var}/modified-files"
 

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -641,7 +641,8 @@ bundle agent garbage_collection
 
         delete => tidy,
         file_select => days_old("&CFENGINE_OUTPUTS_TTL&"),
-        depth_search => recurse("inf");
+        depth_search => recurse("inf"),
+        ifelapsed => "1440"; # 24h
 
       "${g.rudder_var}/modified-files"
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8750