### PR TITLE
Fixes #9013: outputs folder is cleaned at each run

### DIFF
--- a/initial-promises/node-server/promises.cf
+++ b/initial-promises/node-server/promises.cf
@@ -447,7 +447,7 @@ bundle agent garbage_collection
         delete => tidy,
         file_select => days_old("7"),
         depth_search => recurse("inf"),
-        ifelapsed => "1440"; # 24h
+        action => if_elapsed_day;
 
       "${g.rudder_var}/modified-files"
 

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -642,7 +642,7 @@ bundle agent garbage_collection
         delete => tidy,
         file_select => days_old("&CFENGINE_OUTPUTS_TTL&"),
         depth_search => recurse("inf"),
-        ifelapsed => "1440"; # 24h
+        action => if_elapsed_day;
 
       "${g.rudder_var}/modified-files"
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9013