### PR TITLE
Fixes #9060: Specified action bodies override the dry-run policy - Techniques part

### DIFF
--- a/techniques/system/common/1.0/rudder-lib.st
+++ b/techniques/system/common/1.0/rudder-lib.st
@@ -195,6 +195,9 @@ body changes lay_trip_wire
 body action longjob
 {
         ifelapsed => "240"; # run only every 4 hours
+
+     dry_run|global_dry_run::
+        action_policy => "warn";
 }
 
 #######################################################


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9060