### PR TITLE
Fixes #9113: Techniques use \{sys.workdir} for paths of ressources fi…

### DIFF
--- a/techniques/applications/rpmPackageInstallation/3.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/3.0/rpmPackageInstallation.st
@@ -30,7 +30,7 @@
 bundle agent check_rpm_package_installation {
 
 	vars:
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/3.0/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/4.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/4.0/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/4.0/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/4.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/4.1/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/4.1/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.0/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/5.0/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/5.1/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/5.1/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.0/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/6.0/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
 		&RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/6.1/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/6.1/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
       &RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
@@ -33,7 +33,7 @@ bundle agent check_rpm_package_installation {
       &RPM_PACKAGE_CHECK_INTERVAL:{check_interval |"rpm_package_check_interval" string => "&check_interval&";
       }&
 
-      "package_number" int => readstringarrayidx("rpm_data","${sys.workdir}/inputs/rpmPackageInstallation/7.0/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
+      "package_number" int => readstringarrayidx("rpm_data","${this.promise_dirname}/rpmPackageInstallationData", "#[^\n]*",":",9000,1600000);
 &! We need to use the i0 notation to have indexes starting at 0, as in readstringarrayidx !&
 
       &RPM_PACKAGE_REDLIST:{name |"rpm_package[&i0&]" string => "&name&";

--- a/techniques/applications/zypperPackageManagerRepositories/1.0/zypper-repositories-management.st
+++ b/techniques/applications/zypperPackageManagerRepositories/1.0/zypper-repositories-management.st
@@ -58,7 +58,7 @@ bundle agent zypper_repositories_management
       "/etc/zypp/repos.d/rudder-${zypper_name[${zypper_index}]}.repo"
         create        => "true",
         perms         => m("644"),
-        edit_line     => configure_zypper_repos("${zypper_name[${zypper_index}]}", "${zypper_url[${zypper_index}]}", "${zypper_enabled[${zypper_index}]}", "${zypper_type[${zypper_index}]}", "${zypper_autorefresh[${zypper_index}]}", "${sys.workdir}/inputs/zypperPackageManagerRepositories/zypper-repo.tml"),
+        edit_line     => configure_zypper_repos("${zypper_name[${zypper_index}]}", "${zypper_url[${zypper_index}]}", "${zypper_enabled[${zypper_index}]}", "${zypper_type[${zypper_index}]}", "${zypper_autorefresh[${zypper_index}]}", "${this.promise_dirname}/../zypper-repo.tml"),
         edit_defaults => empty_backup,
         classes       => rudder_common_classes("zypper_repo_${zypper_index}");
 

--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/1.0/filesPermissions.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/1.0/filesPermissions.st
@@ -28,7 +28,7 @@ bundle agent files_permissions
 {
   vars:
 
-      "dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1042,102400);
+      "dim_array" int =>  readstringarrayidx("file","${this.promise_dirname}/../permlist","#[^\n]*",":",1042,102400);
 
       "filePerms" slist => getindices("file");
 

--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/1.1/filesPermissions.st
@@ -28,7 +28,7 @@ bundle agent files_permissions
 {
   vars:
 
-      "dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,102400);
+      "dim_array" int =>  readstringarrayidx("file","${this.promise_dirname}/../permlist","#[^\n]*",":",1024,102400);
 
       "filePerms" slist => getindices("file");
 

--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/2.0/filesPermissions.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/2.0/filesPermissions.st
@@ -28,7 +28,7 @@ bundle agent files_permissions
 {
   vars:
 
-      "dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,102400);
+      "dim_array" int =>  readstringarrayidx("file","${this.promise_dirname}/../permlist","#[^\n]*",":",1024,102400);
 
       "filePerms" slist => getindices("file");
 

--- a/techniques/fileConfiguration/fileSecurity/filesPermissions/2.1/filesPermissions.st
+++ b/techniques/fileConfiguration/fileSecurity/filesPermissions/2.1/filesPermissions.st
@@ -28,7 +28,7 @@ bundle agent files_permissions
 {
   vars:
 
-      "dim_array" int =>  readstringarrayidx("file","${sys.workdir}/inputs/filesPermissions/permlist","#[^\n]*",":",1024,102400);
+      "dim_array" int =>  readstringarrayidx("file","${this.promise_dirname}/../permlist","#[^\n]*",":",1024,102400);
 
       "filePerms" slist => getindices("file");
 

--- a/techniques/system/common/1.0/properties.st
+++ b/techniques/system/common/1.0/properties.st
@@ -43,7 +43,7 @@ bundle agent properties
 {
   vars:
     # The files to read
-    "properties_files" slist => findfiles("${sys.workdir}/inputs/properties.d/*.json");
+    "properties_files" slist => findfiles("${this.promise_dirname}/../../properties.d/*.json");
 
     # The sorted file list
     "_sorted_files" slist => sort("properties_files", "lex");

--- a/techniques/system/distributePolicy/1.0/rsyslogConf.st
+++ b/techniques/system/distributePolicy/1.0/rsyslogConf.st
@@ -47,7 +47,7 @@ bundle agent install_rsyslogd {
       "/etc/rsyslog.d/rudder.conf"
         create    => "true",
         edit_defaults => empty_size("8388608"), # the template can get pretty big with a lot of entries
-        edit_line => expand_template("${sys.workdir}/inputs/distributePolicy/rsyslog.conf/${rsyslog_source_file}"),
+        edit_line => expand_template("${this.promise_dirname}/../rsyslog.conf/${rsyslog_source_file}"),
               classes => cf2_if_else("rudder_rsyslog_conf_copied", "cannot_copy_rudder_rsyslog_conf"),
               comment => "Copying rsyslog conf";  
 

--- a/techniques/system/server-roles/1.0/servers-by-role.st
+++ b/techniques/system/server-roles/1.0/servers-by-role.st
@@ -24,7 +24,7 @@ bundle common rudder_servers_by_role
 {
 
   vars:
-      "dim_array" int => readstringarray("roles", "${sys.workdir}/inputs/rudder-server-roles.conf", "#[^\n]*", ":", 15, 4000);
+      "dim_array" int => readstringarray("roles", "${this.promise_dirname}/../../rudder-server-roles.conf", "#[^\n]*", ":", 15, 4000);
 
       "key" slist => getindices("roles");
 

--- a/techniques/systemSettings/process/processManagement/1.0/processManagement.st
+++ b/techniques/systemSettings/process/processManagement/1.0/processManagement.st
@@ -22,7 +22,7 @@ bundle agent process_management
 {
   vars:
 
-      "dim_array" int =>  readstringarray("file","${sys.workdir}/inputs/processManagement/proclist","#[^\n]*",",",15,4000);
+      "dim_array" int =>  readstringarray("file","${this.promise_dirname}/../proclist","#[^\n]*",",",15,4000);
 
       "procList" slist => getindices("file");
 

--- a/techniques/systemSettings/process/processManagement/1.1/processManagement.st
+++ b/techniques/systemSettings/process/processManagement/1.1/processManagement.st
@@ -22,7 +22,7 @@ bundle agent process_management
 {
   vars:
 
-      "dim_array" int =>  readstringarray("file","${sys.workdir}/inputs/processManagement/proclist","#[^\n]*",",",15,4000);
+      "dim_array" int =>  readstringarray("file","${this.promise_dirname}/../proclist","#[^\n]*",",",15,4000);
 
       "procList" slist => getindices("file");
 

--- a/techniques/systemSettings/process/processManagement/2.0/processManagement.st
+++ b/techniques/systemSettings/process/processManagement/2.0/processManagement.st
@@ -22,7 +22,7 @@ bundle agent process_management
 {
   vars:
 
-      "dim_array" int =>  readstringarray("file","${sys.workdir}/inputs/processManagement/proclist","#[^\n]*",",",15,4000);
+      "dim_array" int =>  readstringarray("file","${this.promise_dirname}/../proclist","#[^\n]*",",",15,4000);
 
       "procList" slist => getindices("file");
 


### PR DESCRIPTION
…les (ex: properties), which prevent their validation by the Web Interface during policies generation