### PR TITLE
Fixes #9716: A cfengine enterprise agent fails to connect to rudder server in cfengine 3.7, because there is no agentallconnects

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -169,6 +169,16 @@ body server control
           &endif&
 
         };
+
+        allowallconnects  => {
+          @{def.acl} ,
+          &if(MANAGED_NODES_NAME)&
+          &MANAGED_NODES_NAME: {
+          "&it&"};separator=", "&
+          &endif&
+
+        };
+
 &else&
         trustkeysfrom     => {
           @{def.acl} ,
@@ -187,6 +197,17 @@ body server control
           &endif&
 
         };
+
+
+        allowallconnects  => {
+          @{def.acl} ,
+          &if(MANAGED_NODES_NAME)&
+          &MANAGED_NODES_NAME: {
+          host2ip("&it&"), "&it&"};separator=", "&
+          &endif&
+
+        };
+
 &endif&
 
         maxconnections    => "1000";


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9716