### PR TITLE
Fixes #9317: Wrong warn log report in ssh techniques on sles >= 11

### DIFF
--- a/techniques/systemSettings/remoteAccess/sshConfiguration/4.0/config.st
+++ b/techniques/systemSettings/remoteAccess/sshConfiguration/4.0/config.st
@@ -260,7 +260,7 @@ bundle agent rudder_openssh_server
       ifvarclass => "rudder_openssh_server_allow_agent_forwarding_edit.(redhat|SuSE|debian_3|debian_4)";
     "any"
       usebundle  => rudder_common_report("${rudder_openssh_server_service_name}", "log_warn", "&TRACKINGKEY&", "SSH configuration", "None", "The ${rudder_openssh_server_service_name} parameter \"max sessions\" isn't implemented on Red Hat/CentOS 3,4,5, SuSE 10 and Debian 3 and 4"),
-      ifvarclass => "rudder_openssh_server_max_sessions_edit.(redhat_3|redhat_4|redhat_5|centos_3|centos_4|centos_5|SuSE_10|SuSE|debian_3|debian_4|aix_5_3|aix_5_2|aix_5_1)";
+      ifvarclass => "rudder_openssh_server_max_sessions_edit.(redhat_3|redhat_4|redhat_5|centos_3|centos_4|centos_5|SuSE_10|debian_3|debian_4|aix_5_3|aix_5_2|aix_5_1)";
     "any"
       usebundle  => rudder_common_report("${rudder_openssh_server_service_name}", "log_warn", "&TRACKINGKEY&", "SSH configuration", "None", "The ${rudder_openssh_server_service_name} parameter \"permit tunnel\" isn't implemented on SuSE/Debian 3/Redhat/CentOS3 and 4"),
       ifvarclass => "rudder_openssh_server_permit_tunnel_edit.(SuSE|debian_3|redhat_3|redhat_4|centos_3|centos_4)";

--- a/techniques/systemSettings/remoteAccess/sshConfiguration/5.0/config.st
+++ b/techniques/systemSettings/remoteAccess/sshConfiguration/5.0/config.st
@@ -267,7 +267,7 @@ bundle agent rudder_openssh_server
       ifvarclass => "rudder_openssh_server_allow_agent_forwarding_edit.(redhat|SuSE|debian_3|debian_4)";
     "any"
       usebundle  => rudder_common_report("${rudder_openssh_server_service_name}", "log_warn", "&TRACKINGKEY&", "SSH configuration", "None", "The ${rudder_openssh_server_service_name} parameter \"max sessions\" isn't implemented on Red Hat/CentOS 3,4,5, SuSE 10 and Debian 3 and 4"),
-      ifvarclass => "rudder_openssh_server_max_sessions_edit.(redhat_3|redhat_4|redhat_5|centos_3|centos_4|centos_5|SuSE_10|SuSE|debian_3|debian_4|aix_5_3|aix_5_2|aix_5_1)";
+      ifvarclass => "rudder_openssh_server_max_sessions_edit.(redhat_3|redhat_4|redhat_5|centos_3|centos_4|centos_5|SuSE_10|debian_3|debian_4|aix_5_3|aix_5_2|aix_5_1)";
     "any"
       usebundle  => rudder_common_report("${rudder_openssh_server_service_name}", "log_warn", "&TRACKINGKEY&", "SSH configuration", "None", "The ${rudder_openssh_server_service_name} parameter \"permit tunnel\" isn't implemented on SuSE/Debian 3/Redhat/CentOS3 and 4"),
       ifvarclass => "rudder_openssh_server_permit_tunnel_edit.(SuSE|debian_3|redhat_3|redhat_4|centos_3|centos_4)";


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9317