### PR TITLE
Fixes #8168: If syslog-ng is stopped, it is not restarted automatically by rudder-agent, so agent doesn't report anything

### DIFF
--- a/scripts/check-techniques.sh
+++ b/scripts/check-techniques.sh
@@ -30,7 +30,7 @@ fi
 # Check that the non-existant log level "log_error" is never used
 find ${REPOSITORY_PATH} -type f -name "*.st" | while read filename
 do
-  if grep -rHn "log_error" "$filename" > /dev/null
+  if grep -rHn '"log_error"' "$filename" > /dev/null
   then
     echo "Reason: illegal log level 'log_error' found in $filename. Use result_error instead"
     exit 1

--- a/techniques/system/common/1.0/restart-services.st
+++ b/techniques/system/common/1.0/restart-services.st
@@ -66,4 +66,13 @@ bundle agent restart_services
       "any"  usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not restart the logging system"),
             ifvarclass => "service_restart_rsyslog_not_ok|service_restart_syslog_ng_not_ok|service_restart_syslog_not_ok|${restart_cmd_class}_not_ok";
 
+    # Ensure at least one syslog is running
+    !windows.!aix.!solaris::
+      # We cannot detect which one exist
+      "run_syslog" usebundle   => service_ensure_running("syslog");
+      "run_syslogng" usebundle => service_ensure_running("syslog-ng");
+      "run_rsyslog" usebundle  => service_ensure_running("rsyslog");
+    # We have a problem only if all 3 have an error (otherwise at least one is running)
+    !windows.!aix.!solaris.service_ensure_running_syslog_error.service_ensure_running_syslogng_error.service_ensure_running_rsyslog_error::
+      "any"  usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not start the logging system");
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8168