### PR TITLE
Fixes #9283: Use different package_name_convention in rpm package_method body when there is a defined version

### DIFF
--- a/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
+++ b/techniques/applications/rpmPackageInstallation/7.0/rpmPackageInstallation.st
@@ -234,7 +234,7 @@ body package_method generic_nobulk(rpm_pkg_timeout) {
     package_list_version_regex    => "^\S+?\s(\S+?)\s\S+$";
     package_list_arch_regex       => "^\S+?\s\S+?\s(\S+)$";
     package_installed_regex       => ".*";
-    package_name_convention       => "${name}-${version}";
+    package_name_convention       => "${name}";
     package_list_update_ifelapsed => "${rpm_pkg_timeout}";
     package_add_command           => "/usr/bin/yum ${redhat_knowledge.yum_options} -y install";
     package_delete_command        => "/bin/rpm -e";


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9283