### PR TITLE
Fixes #10987: No logs when (r)?syslog(-ng)? is restarted in 4.1

### DIFF
--- a/techniques/system/common/1.0/restart-services.st
+++ b/techniques/system/common/1.0/restart-services.st
@@ -76,6 +76,11 @@ bundle agent restart_services
       "run_rsyslog" usebundle  => service_ensure_running("rsyslog"),
                     ifvarclass => "!SuSE.rsyslogd_conffile_present";
     # We have a problem only if all 3 have an error (otherwise at least one is running)
-    service_ensure_running_syslog_error.service_ensure_running_syslogng_error.service_ensure_running_rsyslog_error::
+    service_ensure_running_syslog_error.service_ensure_running_syslog_ng_error.service_ensure_running_rsyslog_error::
       "any"  usebundle => rudder_common_report("Common", "result_error", "&TRACKINGKEY&", "Log system for reports", "None", "Could not start the logging system");
+
+    # If syslog service had been restarted, we need to log it as well
+    service_ensure_running_rsyslog_repaired|service_ensure_running_syslog_repaired|service_ensure_running_syslog_ng_repaired::
+      "any"  usebundle => rudder_common_report("Common", "log_repaired", "&TRACKINGKEY&", "Log system for reports", "None", "Started the logging system");
+
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10987