### PR TITLE
Fixes #11151: No new line between two certificates in ca.cert, breaking apache when there is more than one node with a certificate

### DIFF
--- a/techniques/system/distributePolicy/1.0/ca.cert.st
+++ b/techniques/system/distributePolicy/1.0/ca.cert.st
@@ -1,1 +1,2 @@
-&MANAGED_NODES_CERT_PEM&
+&MANAGED_NODES_CERT_PEM: {cert | &cert&
+}&


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11151