### PR TITLE
Fixes #11087: File content (key/value format) technique allows white space before separator but not after it

### DIFF
--- a/maintained-techniques
+++ b/maintained-techniques
@@ -78,6 +78,7 @@ fileDistribution/downloadFile/1.0
 fileDistribution/downloadFile/2.0
 fileDistribution/downloadFile/3.0
 fileDistribution/manageKeyValueFile/1.0
+fileDistribution/manageKeyValueFile/1.1
 jobScheduling/jobScheduler/1.0
 jobScheduling/jobScheduler/2.0
 system/common/1.0

--- a/techniques/fileDistribution/manageKeyValueFile/1.0/metadata.xml
+++ b/techniques/fileDistribution/manageKeyValueFile/1.0/metadata.xml
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- This technique lets user define a key-value in a file -->
 <TECHNIQUE name="Manage keys-values in file">
-  <DEPRECATED>This technique version has been superseded by a new version. It will no longer be available in the next stable version of Rudder. Please upgrade to the latest version.</DEPRECATED>
   <DESCRIPTION>Manage keys-values in file</DESCRIPTION>
   <MULTIINSTANCE>true</MULTIINSTANCE>
   <COMPATIBLE>

--- a/techniques/fileDistribution/manageKeyValueFile/1.1/changelog
+++ b/techniques/fileDistribution/manageKeyValueFile/1.1/changelog
@@ -1,0 +1,3 @@
+ -- Nicolas Charles <nicolas.charles@normation.com> Tue Sep 12 18:45:08 2017
+  * Version 1.1
+  ** Add an option to be strict on spaces around separator

--- a/techniques/fileDistribution/manageKeyValueFile/1.1/manage-key-value-file.st
+++ b/techniques/fileDistribution/manageKeyValueFile/1.1/manage-key-value-file.st
@@ -26,6 +26,8 @@ bundle agent manage_key_value_file {
 }&
       &MANAGE_KEY_VALUE_SEPARATOR:{separator |  "separator[&i&]"   string => "&separator&";
 }&
+      &MANAGE_KEY_VALUE_OPTION:{option |  "option[&i&]"   string => "&option&";
+}&
       &TRACKINGKEY:{uuid |  "trackingkey[&i&]" string => "&uuid&";
 }&
 
@@ -35,8 +37,10 @@ bundle agent manage_key_value_file {
     "canonified_file[${index}]"      string => canonify("${file[${index}]}");
     "class_prefix_${index}"          string => "file_ensure_key_value_${canonified_file[${index}]}";
     "technique_name"                 string => "Manage keys-values file";
+
+
   methods:
-    "apply_${index}"   usebundle => file_ensure_key_value("${file[${index}]}", "${key[${index}]}", "${value[${index}]}", "${separator[${index}]}");
-    "report_${index}"  usebundle => rudder_common_reports_generic_index("${technique_name}", "${class_prefix_${index}}",    "${trackingkey[${index}]}", "File", "${file[${index}]}", "The key -> value ${key[${index}]} ${separator[${index}]} ${value[${index}]}", "${index}");
+    "apply_${index}"   usebundle => file_ensure_key_value_option("${file[${index}]}", "${key[${index}]}", "${value[${index}]}", "${separator[${index}]}", "${option[${index}]}");
+    "report_${index}"  usebundle => rudder_common_reports_generic_index("${technique_name}", "${class_prefix_${index}}",    "${trackingkey[${index}]}", "File", "${file[${index}]}", "The key -> value ${key[${index}]} ${separator[${index}]} ${value[${index}]} with ${option[${index}]} spacing around the separator", "${index}");
 
 }

--- a/techniques/fileDistribution/manageKeyValueFile/1.1/manage-key-value-file.st
+++ b/techniques/fileDistribution/manageKeyValueFile/1.1/manage-key-value-file.st
@@ -1,0 +1,42 @@
+#####################################################################################
+# Copyright 2016 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+bundle agent manage_key_value_file {
+  vars:
+      &MANAGE_KEY_VALUE_FILEPATH:{file |  "file[&i&]"        string => "&file&";
+}&
+      &MANAGE_KEY_VALUE_KEY:{key |  "key[&i&]"         string => "&key&";
+}&
+      &MANAGE_KEY_VALUE_VALUE:{value |  "value[&i&]"       string => "&value&";
+}&
+      &MANAGE_KEY_VALUE_SEPARATOR:{separator |  "separator[&i&]"   string => "&separator&";
+}&
+      &TRACKINGKEY:{uuid |  "trackingkey[&i&]" string => "&uuid&";
+}&
+
+
+    "index" slist => getindices("file");
+
+    "canonified_file[${index}]"      string => canonify("${file[${index}]}");
+    "class_prefix_${index}"          string => "file_ensure_key_value_${canonified_file[${index}]}";
+    "technique_name"                 string => "Manage keys-values file";
+  methods:
+    "apply_${index}"   usebundle => file_ensure_key_value("${file[${index}]}", "${key[${index}]}", "${value[${index}]}", "${separator[${index}]}");
+    "report_${index}"  usebundle => rudder_common_reports_generic_index("${technique_name}", "${class_prefix_${index}}",    "${trackingkey[${index}]}", "File", "${file[${index}]}", "The key -> value ${key[${index}]} ${separator[${index}]} ${value[${index}]}", "${index}");
+
+}

--- a/techniques/fileDistribution/manageKeyValueFile/1.1/metadata.xml
+++ b/techniques/fileDistribution/manageKeyValueFile/1.1/metadata.xml
@@ -16,7 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- This technique lets user define a key-value in a file -->
 <TECHNIQUE name="Manage keys-values in file">
-  <DEPRECATED>This technique version has been superseded by a new version. It will no longer be available in the next stable version of Rudder. Please upgrade to the latest version.</DEPRECATED>
   <DESCRIPTION>Manage keys-values in file</DESCRIPTION>
   <MULTIINSTANCE>true</MULTIINSTANCE>
   <COMPATIBLE>

--- a/techniques/fileDistribution/manageKeyValueFile/1.1/metadata.xml
+++ b/techniques/fileDistribution/manageKeyValueFile/1.1/metadata.xml
@@ -65,6 +65,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <TYPE>string</TYPE>
           </CONSTRAINT>
         </INPUT>
+        <SELECT1>
+          <NAME>MANAGE_KEY_VALUE_OPTION</NAME>
+          <DESCRIPTION>Prevent spaces around separator</DESCRIPTION>
+          <LONGDESCRIPTION>If "No spacing" is selected, this will prevent any spaces around the separator, enforcing strictly KEY=VALUE; otherwise any number of spaces will be accepted before or after the separator.</LONGDESCRIPTION>
+          <ITEM>
+            <VALUE>strict</VALUE>
+            <LABEL>No spacing</LABEL>
+          </ITEM>
+          <ITEM>
+            <VALUE>lax</VALUE>
+            <LABEL>Any number of spaces</LABEL>
+          </ITEM>
+          <CONSTRAINT>
+            <DEFAULT>lax</DEFAULT>
+          </CONSTRAINT>
+        </SELECT1>
       </SECTION>
     </SECTION>
   </SECTIONS>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11087