### PR TITLE
Fixes #11613: generic_variable_definition inserts spaces in multi lined values

### DIFF
--- a/techniques/systemSettings/misc/genericCommandVariableDefinition/1.0/genericCommandVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericCommandVariableDefinition/1.0/genericCommandVariableDefinition.st
@@ -20,7 +20,7 @@ bundle common generic_cmd_var_def {
 
 	vars:
 
-		&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
+&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
 }&
 		
 }

--- a/techniques/systemSettings/misc/genericCommandVariableDefinition/2.0/genericCommandVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericCommandVariableDefinition/2.0/genericCommandVariableDefinition.st
@@ -20,7 +20,7 @@ bundle common generic_cmd_var_def {
 
 	vars:
 
-		&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
+&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
 }&
 		
 }

--- a/techniques/systemSettings/misc/genericCommandVariableDefinition/3.0/genericCommandVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericCommandVariableDefinition/3.0/genericCommandVariableDefinition.st
@@ -20,7 +20,7 @@ bundle common generic_cmd_var_def {
 
 	vars:
 
-		&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
+&GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
 }&
 		
 }

--- a/techniques/systemSettings/misc/genericVariableDefinition/1.0/genericVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericVariableDefinition/1.0/genericVariableDefinition.st
@@ -21,7 +21,7 @@ bundle common generic_variable_definition
 
   vars:
 
-    &GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&";
+&GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&";
 }&
 }
 

--- a/techniques/systemSettings/misc/genericVariableDefinition/1.1/genericVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericVariableDefinition/1.1/genericVariableDefinition.st
@@ -21,7 +21,7 @@ bundle common generic_variable_definition
 
   vars:
 
-    &GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&";
+&GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&";
 }&
 
 }

--- a/techniques/systemSettings/misc/genericVariableDefinition/1.2/genericVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericVariableDefinition/1.2/genericVariableDefinition.st
@@ -21,7 +21,7 @@ bundle common generic_variable_definition
 
   vars:
 
-    &GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&",
+&GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&",
         policy => "overridable";
 }&
 

--- a/techniques/systemSettings/misc/genericVariableDefinition/2.0/genericVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericVariableDefinition/2.0/genericVariableDefinition.st
@@ -21,7 +21,7 @@ bundle common generic_variable_definition
 
   vars:
 
-    &GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&",
+&GENERIC_VARIABLE_NAME, GENERIC_VARIABLE_CONTENT:{name, content |"&name&" string => "&content&",
         policy => "overridable";
 }&
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11613