### PR TITLE
Fixes #10912: Duration of logrotate for /var/log/rudder/  is too long making /var/log too big

### DIFF
--- a/initial-promises/node-server/server-roles/1.0/logrotate-check.cf
+++ b/initial-promises/node-server/server-roles/1.0/logrotate-check.cf
@@ -48,6 +48,8 @@ bundle agent root_logrotate_check
         string => "reload",
         policy => "overridable";
 
+     "logrotate_duration" string => "30";
+
     ubuntu::
       "syslog_user"             string => "syslog";
 

--- a/initial-promises/node-server/server-roles/logrotate.conf/rudder
+++ b/initial-promises/node-server/server-roles/logrotate.conf/rudder
@@ -8,7 +8,7 @@
 /var/log/rudder/apache2/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -23,7 +23,7 @@
 /var/log/rudder/reports/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -38,7 +38,7 @@
 /var/log/rudder/reports/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -53,7 +53,7 @@
 /var/log/rudder/ldap/slapd.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -67,7 +67,7 @@
 /var/log/rudder/ldap/slapd.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}

--- a/techniques/system/server-roles/1.0/logrotate-check.st
+++ b/techniques/system/server-roles/1.0/logrotate-check.st
@@ -48,6 +48,11 @@ bundle agent root_logrotate_check
         string => "reload",
         policy => "overridable";
 
+    pass1.!duration_configured::
+      "logrotate_duration" string => "30";
+    pass1.duration_configured::
+      "logrotate_duration" string => "${rudder_parameters.log_duration}";
+
     ubuntu::
       "syslog_user"             string => "syslog";
 
@@ -68,8 +73,14 @@ bundle agent root_logrotate_check
 
       "syslog_rotation_method"  string => "rotate";
 
+  classes:
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
+      "duration_configured" expression => isvariable("rudder_parameters.log_duration");
+
   files:
 
+    pass2::
       "/etc/logrotate.d/rudder"
         create        => "true",
         edit_defaults => empty_backup,

--- a/techniques/system/server-roles/1.0/rudder-logrotate.st
+++ b/techniques/system/server-roles/1.0/rudder-logrotate.st
@@ -8,7 +8,7 @@
 /var/log/rudder/apache2/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -23,7 +23,7 @@
 /var/log/rudder/reports/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -38,7 +38,7 @@
 /var/log/rudder/reports/*.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -53,7 +53,7 @@
 /var/log/rudder/ldap/slapd.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}
@@ -67,7 +67,7 @@
 /var/log/rudder/ldap/slapd.log {
         daily
         missingok
-        rotate 30
+        rotate ${root_logrotate_check.logrotate_duration}
         compress
         notifempty
         create ${root_logrotate_check.syslog_file_mode} ${root_logrotate_check.syslog_user} ${root_logrotate_check.syslog_group}


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10912