### PR TITLE
Fixes #11803: On update error, the help message is not valid anymore

### DIFF
--- a/techniques/system/common/1.0/update.st
+++ b/techniques/system/common/1.0/update.st
@@ -372,7 +372,6 @@ bundle agent update_action
        "*********************************************************************************
 * rudder-agent could not get an updated configuration from the policy server.   *
 * This can be caused by:                                                        *
-*   * an incorrect DNS resolution of this node                                  *
 *   * an agent key that has been changed                                        *
 *   * if this node is not accepted or deleted node on the Rudder root server    *
 *   * if this node has changed policy server without sending a new inventory    *


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11803

Replacing previous PR: https://github.com/Normation/rudder-techniques/pull/1224
