### PR TITLE
Fixes #12042: Inventory validation broken on Centos 7 on Rudder 4.3

### DIFF
--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -602,7 +602,7 @@ bundle agent checkInventoryFile
     !windows.has_rudder_perl::
       "perl_command" string => "/opt/rudder/bin/perl -I /opt/rudder/lib/perl5";
     !windows.!has_rudder_perl::
-      "perl_command" string => "/usr/bin/perl";
+      "perl_command" string => "/usr/bin/perl -I /opt/rudder/lib/perl5";
     windows::
       "perl_command" string => "C:\Program Files\FusionInventory-Agent\perl\bin\perl.exe";
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12042