### PR TITLE
Fixes #12242: Error at node installation - Can't stat file '/var/rudder/cfengine-community/inputs/inventory/1.0/virtualMachines.cf' for parsing. (stat: No such file or directory)

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -27,7 +27,7 @@
   "NODEROLE": "# This node doesn't have any specific role",
   "RUDDER_DIRECTIVES_INPUTS": "",
   "RUDDER_DIRECTIVES_SEQUENCE": "",
-  "RUDDER_SYSTEM_DIRECTIVES_INPUTS": "\"common/1.0/cf-serverd.cf\",\"common/1.0/rudder-stdlib.cf\",\"common/1.0/rudder-stdlib-core.cf\",\"common/1.0/rudder-lib.cf\",\"common/1.0/cron-setup.cf\",\"common/1.0/internal-security.cf\",\"common/1.0/site.cf\",\"common/1.0/update.cf\",\"inventory/1.0/virtualMachines.cf\",\"inventory/1.0/fusionAgent.cf\"",
+  "RUDDER_SYSTEM_DIRECTIVES_INPUTS": "\"common/1.0/cf-serverd.cf\",\"common/1.0/rudder-stdlib.cf\",\"common/1.0/rudder-stdlib-core.cf\",\"common/1.0/rudder-lib.cf\",\"common/1.0/cron-setup.cf\",\"common/1.0/internal-security.cf\",\"common/1.0/site.cf\",\"common/1.0/update.cf\",\"inventory/1.0/fusionAgent.cf\"",
   "RUDDER_SYSTEM_DIRECTIVES_SEQUENCE": "",
   "RUDDER_REPORTS_DB_NAME": "rudder",
   "RUDDER_REPORTS_DB_USER": "rudder"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12242