### PR TITLE
Fixes #12521: Access rules on Rudder servers/relays prevent in most case the server from downloading/connecting on itself

### DIFF
--- a/techniques/system/common/1.0/cf-served.st
+++ b/techniques/system/common/1.0/cf-served.st
@@ -159,7 +159,7 @@ bundle common def
 
     policy_server::
       "acl" slist => {
-      "127.0.0.0/8" , "::1",
+      "127.0.0.0/8" , "::1", @{sys.ip_addresses},
 &if(AUTHORIZED_NETWORKS)&
       host2ip("${def.policy_server}"), # the policy server can connect to a relay
       &AUTHORIZED_NETWORKS:{net|"&net&",}&


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12521