### PR TITLE
Fixes #12530: apache_acl file is remplaced, even on relay with no http

### DIFF
--- a/techniques/system/distributePolicy/1.0/apache-acl.st
+++ b/techniques/system/distributePolicy/1.0/apache-acl.st
@@ -44,7 +44,7 @@ bundle agent apache_acl
       "pass1" expression => "any";
 
   files:
-    pass2::
+    !role_rudder_relay_promises_only.pass2::
       "${destination}/${ssl_ca_file}"
         create        => "true",
         perms         => mog("600", "root", "0"),
@@ -74,4 +74,8 @@ bundle agent apache_acl
 
       "any" usebundle => rudder_common_report("DistributePolicy", "result_error", "&TRACKINGKEY&", "Configure apache ACL", "None", "Apache failed to reload"),
             ifvarclass => "service_reload_${apache_service}_error";
+
+    role_rudder_relay_promises_only::
+      "any" usebundle => rudder_common_report("DistributePolicy", "result_na", "&TRACKINGKEY&", "Configure apache ACL", "None", "Apache is not managed");
+
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12530