### PR TITLE
Fixes #12563: monitoring_hook do no exist in initial promises

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -87,9 +87,9 @@ bundle common va
       "end" slist => {
 &if(!INITIAL)&
         "restart_services", 
+        "monitoring_hook_post",
 &endif&
 
-        "monitoring_hook_post",
         "endExecution"
       };
 
@@ -116,9 +116,9 @@ bundle common va
         "get_environment_variables",
         "properties",
         "nxlog_enable",
+        "monitoring_hook_pre",
 &endif&
 
-        "monitoring_hook_pre"
       };
 
     policy_server::


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12563