### PR TITLE
Fixes #12610: Make the 'common' system technique identify crond on a slackware agent

### DIFF
--- a/techniques/system/common/1.0/cron-setup.st
+++ b/techniques/system/common/1.0/cron-setup.st
@@ -83,9 +83,9 @@ bundle agent check_cron_daemon
 {
   vars:
 
-    redhat|fedora::
+    redhat|fedora|slackware::
       "service_name" string => "crond";
-    !(redhat|fedora)::
+    !(redhat|fedora|slackware)::
       "service_name" string => "cron";
 
   classes:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12610