### PR TITLE
Fixes #12615: rudder-lib.st in the "common" system technique does not identify crond as running when the ps is /usr/sbin/crond -l notice

### DIFF
--- a/techniques/system/common/1.0/rudder-lib.st
+++ b/techniques/system/common/1.0/rudder-lib.st
@@ -678,6 +678,6 @@ select_end => "\S*:\s*";
 
 body process_select cron_bin
 {
-  command => "(/usr/sbin/)?crond?( -n| -f)?";
+  command => "(/usr/sbin/)?crond?( -n| -f | -l notice)*";
   process_result => "command";
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12615