### PR TITLE
Fixes #14135: Abort when running 5.1 policies on old agent

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -81,6 +81,8 @@ bundle common va
         "update_reports",
         "configuration",
         "initialize_ncf",
+	# We need ncf to be loaded and initialized
+	"rudder_check_agent_version",
         "internal_security",
         "check_uuid",
         "garbage_collection",
@@ -655,6 +657,15 @@ bundle agent update_reports
         action => immediate;
 }
 
+
+#######################################################
+
+bundle agent rudder_check_agent_version
+{
+  methods:
+    cfengine_3_1|cfengine_3_2|cfengine_3_3|cfengine_3_4|cfengine_3_5|cfengine_3_6|cfengine_3_7|cfengine_3_8|cfengine_3_9::
+      "any" usebundle => _abort("unsupported_agent", "This agent is not compatible with its Rudder server, please upgrade");
+}
 
 #######################################################
 


### PR DESCRIPTION
https://issues.rudder.io/issues/14135