### PR TITLE
Fixes #14350: missing reports in rudder 5.1 because of undefined distribute_policy_common.directiveId

### DIFF
--- a/techniques/system/distributePolicy/1.0/common.st
+++ b/techniques/system/distributePolicy/1.0/common.st
@@ -1,7 +1,7 @@
 # Common variable for distribute policy system technique
 bundle common distribute_policy_common {
   vars:
-    "directiveId"            string => "${distribute_policy_common.directiveId}";
+    "directiveId"            string => "&TRACKINGKEY&";
     "report_db_name"         string => "&RUDDER_REPORTS_DB_NAME&";
     "report_db_user"         string => "&RUDDER_REPORTS_DB_USER&";
     "relay_sync_method"      string => "&RELAY_SYNC_METHOD&";


### PR DESCRIPTION
https://issues.rudder.io/issues/14350