### PR TITLE
Fixes #14687: rudder-directives.cf is included twice in policies 

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -56,10 +56,6 @@ body common control
         inputs => {
           @{va.inputs_list},
           "rudder-system-directives.cf",
-&if(!INITIAL)&
-          "rudder-directives.cf"
-&endif&
-
         };
 
         bundlesequence => { 


### PR DESCRIPTION
https://issues.rudder.io/issues/14687