### PR TITLE
Fixes #15234: Broken promise_dirname variable prevents relayd configuration

### DIFF
--- a/techniques/system/server-roles/1.0/relayd.cf
+++ b/techniques/system/server-roles/1.0/relayd.cf
@@ -26,7 +26,7 @@ bundle agent rudder_relayd_configuration {
   methods:
       "any" usebundle => disable_reporting;
       "any" usebundle => _method_reporting_context("${component}", "None");
-      "any" usebundle => file_from_template_mustache("${this.promise_dir}/relayd.conf.tpl", "${config_file}");
+      "any" usebundle => file_from_template_mustache("${this.promise_dirname}/relayd.conf.tpl", "${config_file}");
       "any" usebundle => service_restart("rudder-relayd"),
                    if => "${file_class_prefix}_repaired";
       "any" usebundle => enable_reporting;


### PR DESCRIPTION
https://issues.rudder.io/issues/15234