### PR TITLE
Fixes #15322: agents in 5.1 fail to download ncf from the server

### DIFF
--- a/bootstrap-promises/failsafe.cf
+++ b/bootstrap-promises/failsafe.cf
@@ -88,7 +88,7 @@ bundle agent update
         classes           => classes_generic("config");
 
       "${ncf_common}"
-        copy_from         => remote("${server_info.policy_server}", "${ncf_common_ncf}"),
+        copy_from         => remote("${server_info.policy_server}", "${ncf_common_src}"),
         depth_search      => recurse("inf"),
         perms             => u_mog("644", "root", "0"),
         action            => immediate,


### PR DESCRIPTION
https://issues.rudder.io/issues/15322