### PR TITLE
Fixes #15801: Rudder agent cannot copy the certificate if the user defined one that is a link to a file in a different mount point

### DIFF
--- a/techniques/system/distributePolicy/1.0/apache-acl.st
+++ b/techniques/system/distributePolicy/1.0/apache-acl.st
@@ -46,7 +46,6 @@ bundle agent apache_acl
   files:
     !role_rudder_relay_promises_only.pass2::
       "${destination}/${ssl_ca_file}"
-        create        => "true",
         perms         => mog("600", "root", "0"),
         copy_from     => ncf_local_cp_method("${src_ca_file}", "digest"),
         classes       => rudder_common_classes("rudder_apache_acl"),


### PR DESCRIPTION
https://issues.rudder.io/issues/15801