### PR TITLE
Fixes #16002: When switching to HTTPS reporting, the compliance of root server is broken because it receives both https and syslog

### DIFF
--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
@@ -30,6 +30,7 @@ $ActionQueueSaveOnShutdown on
 # If report protocol is HTTPS, we drop the local rsyslog message
 {{#classes.rudder_reporting_https}}
 if $fromhost-ip == "127.0.0.1" then {
+    :programname, isequal, "cf-agent" ~
     :programname, isequal, "rudder" ~
 }
 {{/classes.rudder_reporting_https}}

--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-root.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-root.st
@@ -48,6 +48,7 @@ $template RudderReportsFormat,"insert into RudderSysEvents (executionDate, nodeI
 # If report protocol is HTTPS, we drop the local rsyslog message
 {{#classes.rudder_reporting_https}}
 if $fromhost-ip == "127.0.0.1" then {
+    :programname, isequal, "cf-agent" ~
     :programname, isequal, "rudder" ~
 }
 {{/classes.rudder_reporting_https}}


### PR DESCRIPTION
https://issues.rudder.io/issues/16002