### PR TITLE
Fixes #16139: Files distributed via apache but download by the agent on relays have the wrong permissions

### DIFF
--- a/techniques/system/distributePolicy/1.0/propagatePromises.st
+++ b/techniques/system/distributePolicy/1.0/propagatePromises.st
@@ -92,6 +92,7 @@ bundle agent propagatePromises
       "${client_data}"  #that's a loop on each files in client_inputs
         copy_from    => remote("${server_info.policy_server}","${server_data}"),
         depth_search => recurse_visible("inf"),
+        perms => mog("2750", "root", "rudder-policy-reader"),
         comment => "Fetching the promises to propagate",
         classes => if_else("promises_propagated", "could_not_propagate_promises");
 


### PR DESCRIPTION
https://issues.rudder.io/issues/16139