### PR TITLE
Fixes #16116: When syslog reporting is disabled, we should also remove remove_limits.conf from rsyslog config

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -502,6 +502,9 @@ bundle agent remove_rudder_syslog_configuration {
         delete         => tidy,
         classes        => classes_generic("remove_rudder_syslog_configuration_rsyslog");
 
+      "/etc/rsyslog.d/remove_limit.conf"
+        delete         => tidy;
+
     syslogng::
       "${check_log_system.syslogng_conffile}"
         edit_line      => delete_lines_matching("${syslogng_delete_lines_patterns}"),


### PR DESCRIPTION
https://issues.rudder.io/issues/16116