### PR TITLE
Fixes #16710: In HTTPS + syslog mode, agents without the http support (like 5.0) don't have their syslog configured

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -278,15 +278,40 @@ bundle agent initialize_ncf()
 &if(!INITIAL)&
 bundle agent configure_rudder_reporting_system {
   methods:
-    rudder_reporting_syslog.!reports_disabled::
+    !rsyslog_disabled.!reports_disabled.policy_server::
+      "define rsyslog configuration for relays" usebundle => rsyslog_system_settings;
+
+    (rudder_reporting_syslog|!agent_capability_http_reporting).!reports_disabled::
       "configure_syslog"    usebundle => check_log_system;
       "configure_reporting" usebundle => check_rsyslog_version;
 
-    (rudder_reporting_syslog.reports_disabled)|rudder_reporting_https::
+    reports_disabled|(rudder_reporting_https.rsyslog_disabled)::
       "remove_reporting"    usebundle => remove_rudder_syslog_configuration;
 
-    rudder_reporting_https::
+    rudder_reporting_https.agent_capability_http_reporting::
       "make http reports"   usebundle => send_rudder_reports;
+
+  reports:
+    rsyslog_disabled.!agent_capability_http_reporting.!reports_disabled::
+      "***********************************************************************************
+       * rudder-agent is configured to use HTTPS reporting only, but this agent doesn't  * 
+       * support HTTPS. Please upgrade rudder-agent to version 6.0 or more, or modify    *
+       * reporting configuration within Rudder                                           *
+       ***********************************************************************************";
+}
+
+# Configure rsyslog config for relays
+bundle agent rsyslog_system_settings
+{
+  vars:
+    use_tcp::
+      "rsyslog_rule_prefix"   string => "@@";
+    use_udp::
+      "rsyslog_rule_prefix"   string => "@";
+
+  classes:
+      "use_udp" expression => strcmp("&RUDDER_SYSLOG_PROTOCOL&", "UDP");
+      "use_tcp" expression => strcmp("&RUDDER_SYSLOG_PROTOCOL&", "TCP");
 }
 
 #######################################################

--- a/techniques/system/common/1.0/reporting-http.cf
+++ b/techniques/system/common/1.0/reporting-http.cf
@@ -24,6 +24,7 @@ bundle agent send_rudder_report(path) {
 bundle agent send_rudder_reports
 {
   vars:
+    agent_capability_http_reporting::
       "raw_reports" slist => lsdir("${g.rudder_reports}/ready/", ".*\.log.gz", "false");
       # Max 50 reports by run to avoid blocking the agent too long after a long
       # disconnection

--- a/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
+++ b/techniques/system/distributePolicy/1.0/rudder-rsyslog-relay.st
@@ -41,7 +41,7 @@ if $fromhost-ip == "127.0.0.1" then {
 #
 
 # 1 - Send every matching report to the root server
-:msg, ereregex, "(R: )?@@[ a-zA-Z0-9_\-]+?@@[a-zA-Z0-9_\-]{1,64}?@@[a-zA-Z0-9\-]+@@[a-zA-Z0-9\-]+?@@[0-9]+?@@.*?@@.*?@@[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{1,2}:[0-9]{2}##[a-zA-Z0-9\-]+?@#.*" {{vars.check_log_system.rsyslog_rule_prefix}}{{vars.server_info.policy_server}}:&SYSLOGPORT&
+:msg, ereregex, "(R: )?@@[ a-zA-Z0-9_\-]+?@@[a-zA-Z0-9_\-]{1,64}?@@[a-zA-Z0-9\-]+@@[a-zA-Z0-9\-]+?@@[0-9]+?@@.*?@@.*?@@[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{1,2}:[0-9]{2}##[a-zA-Z0-9\-]+?@#.*" {{vars.rsyslog_system_settings.rsyslog_rule_prefix}}{{vars.server_info.policy_server}}:&SYSLOGPORT&
 
 # 2 - Drop the remaining rudder logs to prevent local storage cluttering
 


### PR DESCRIPTION
https://issues.rudder.io/issues/16710