### PR TITLE
Fixes #16716: 5.0.15 and lower agents can not update when managed by a 6.0+ server or relay

### DIFF
--- a/techniques/system/common/1.0/cf-serverd.st
+++ b/techniques/system/common/1.0/cf-serverd.st
@@ -125,8 +125,12 @@ body server control
           @{def.acl} ,
         };
 
+	# WARNING: this is disabled for compatibility with pre 5.0.16 agent
+	# that do not properly handle minimal TLS version setting and use 1.0
+	# https://issues.rudder.io/issues/16716
+	# TODO: uncomment once compatibility with 5.0 is dropped
         # force connections via tls1.2
-        allowtlsversion => "1.2";
+        # allowtlsversion => "1.2";
 
         maxconnections    => "1000";
         logallconnections => "true";

--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -11,7 +11,8 @@ body common control
 
         protocol_version   => "2";
 
-        # force tls1.2
+        # force tls1.2 (see promises.cf for details)
+      !cfengine_3_12|(cfengine_3_12.!(cfengine_3_12_0|cfengine_3_12_1|cfengine_3_12_2))::
         tls_min_version => "1.2";
 }
 

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -39,9 +39,14 @@ body common control
           "rudder-system-directives.cf",
         };
 
-        # force tls1.2
+        # force tls1.2 on compatible clients
+        # we only support 5.0+, so 3.12+
+	# let's force TLS 1.2 on:
+	# >3.12 | (3.12 if > 3.12.2)
+      !cfengine_3_12|(cfengine_3_12.!(cfengine_3_12_0|cfengine_3_12_1|cfengine_3_12_2))::
         tls_min_version => "1.2";
 
+      any::
         bundlesequence => {
           rudder_init,
           rudder_common_system_directive,


### PR DESCRIPTION
https://issues.rudder.io/issues/16716