### PR TITLE
Fixes #16849: When using twice directive packageManagement 1.2, once to ensure presence of a package, and second one to upgrade the package, reporting and posthook is wrong on the second one

### DIFF
--- a/techniques/applications/packageManagement/1.2/packageManagement.st
+++ b/techniques/applications/packageManagement/1.2/packageManagement.st
@@ -100,18 +100,22 @@ bundle agent package_management_RudderUniqueID {
 
       # Name of the ncf bundle. We use a variable to avoid breaking the syntax if the bundle does not exist.
       "bundle_name" string => "package_state_options";
+
+      # define inner class prefix
+      "full_inner_class_prefix" string => canonify("package_state_options_${package[${index_pkg}]}_${version[${index_pkg}]}_${architecture[${index_pkg}]}_${manager[${index_pkg}]}_${state[${index_pkg}]}_${manager_final_options[${index_pkg}]}");
+      "inner_class_prefix"      string => string_head("${full_inner_class_prefix}", "1000");
    
   classes:
       # This class is different from the one in ncf (where a version number and latest are considered "specified")
-      "version_specified_${index_pkg}" expression => strcmp("${version[${index_pkg}]}", "specific");
+      "version_specified_${index_pkg}"      expression => strcmp("${version[${index_pkg}]}", "specific");
       "architecture_specified_${index_pkg}" expression => strcmp("${architecture[${index_pkg}]}", "specific");
-      "posthook_specified_${index_pkg}" not => strcmp("${posthook[${index_pkg}]}", "");
-      "manager_specified_${index_pkg}" not => strcmp("${manager[${index_pkg}]}", "default");
-      "state_present_${index_pkg}" expression => strcmp("${state[${index_pkg}]}", "present");
-      "version_latest_${index_pkg}" expression => strcmp("${version[${index_pkg}]}", "latest");
-      "allow_unstrusted_${index_pkg}" expression => strcmp("${manager_allow_untrusted[${index_pkg}]}", "true");
-      "manager_apt_${index_pkg}" expression => strcmp("${manager[${index_pkg}]}", "apt");
-      "apt_allow_untrusted_${index_pkg}" expression => "allow_unstrusted_${index_pkg}.((debian.!manager_specified_${index_pkg})|manager_apt_${index_pkg})";
+      "posthook_specified_${index_pkg}"            not => strcmp("${posthook[${index_pkg}]}", "");
+      "manager_specified_${index_pkg}"             not => strcmp("${manager[${index_pkg}]}", "default");
+      "state_present_${index_pkg}"          expression => strcmp("${state[${index_pkg}]}", "present");
+      "version_latest_${index_pkg}"         expression => strcmp("${version[${index_pkg}]}", "latest");
+      "allow_unstrusted_${index_pkg}"       expression => strcmp("${manager_allow_untrusted[${index_pkg}]}", "true");
+      "manager_apt_${index_pkg}"            expression => strcmp("${manager[${index_pkg}]}", "apt");
+      "apt_allow_untrusted_${index_pkg}"    expression => "allow_unstrusted_${index_pkg}.((debian.!manager_specified_${index_pkg})|manager_apt_${index_pkg})";
 
       "pass3" expression => "pass2";
       "pass2" expression => "pass1";
@@ -128,17 +132,19 @@ bundle agent package_management_RudderUniqueID {
       # Package
       "package_${index_pkg}" usebundle => ${bundle_name}("${package[${index_pkg}]}", "${version[${index_pkg}]}", "${architecture[${index_pkg}]}", "${manager[${index_pkg}]}", "${state[${index_pkg}]}", "${manager_final_options[${index_pkg}]}");
 
-      "report_${index_pkg}" usebundle => rudder_common_reports_generic_index("packageManagement", "${class_prefix_package[${index_pkg}]}", "${trackingkey[${index_pkg}]}", "Package", "${package[${index_pkg}]}", "${state_description[${index_pkg}]} of package ${package[${index_pkg}]}${architecture_description[${index_pkg}]}${version_description[${index_pkg}]}", "${index_pkg}");
+      "report_${index_pkg}" usebundle => rudder_common_reports_generic_index("packageManagement", "${inner_class_prefix}", "${trackingkey[${index_pkg}]}", "Package", "${package[${index_pkg}]}", "${state_description[${index_pkg}]} of package ${package[${index_pkg}]}${architecture_description[${index_pkg}]}${version_description[${index_pkg}]}", "${index_pkg}");
 
       # Post-modification script
-      "post_hook_${index_pkg}" usebundle  => command_execution("${posthook[${index_pkg}]}"),
-                               ifvarclass => "posthook_specified_${index_pkg}.${class_prefix_package[${index_pkg}]}_repaired";
+      "post_hook_${index_pkg}"  usebundle => command_execution("${posthook[${index_pkg}]}"),
+                               ifvarclass => "posthook_specified_${index_pkg}.${inner_class_prefix}_repaired";
 
-      "report_${index_pkg}" usebundle  => rudder_common_reports_generic_index("packageManagement", "${class_prefix_script[${index_pkg}]}", "${trackingkey[${index_pkg}]}", "Post-modification script", "${package[${index_pkg}]}", "Execution of the post-modification script", "${index_pkg}"),
-                            ifvarclass => "${class_prefix_script[${index_pkg}]}_reached";
+      "report_${index_pkg}"     usebundle => rudder_common_report("packageManagement", "result_na", "${trackingkey[${index_pkg}]}", "Post-modification script", "${package[${index_pkg}]}", "No post-modification script was defined"),
+                               ifvarclass => "!posthook_specified_${index_pkg}";
 
-      "report_${index_pkg}" usebundle  => rudder_common_report("packageManagement", "result_na", "${trackingkey[${index_pkg}]}", "Post-modification script", "${package[${index_pkg}]}", "No post-modification script was set to run"),
-                            ifvarclass => "!${class_prefix_script[${index_pkg}]}_reached";
+      "report_${index_pkg}"     usebundle => rudder_common_report("packageManagement", "result_na", "${trackingkey[${index_pkg}]}", "Post-modification script", "${package[${index_pkg}]}", "Post-modification script was not to be run"),
+                               ifvarclass => "posthook_specified_${index_pkg}.!${inner_class_prefix}_repaired";
 
+      "report_${index_pkg}"     usebundle => rudder_common_reports_generic_index("packageManagement", "${class_prefix_script[${index_pkg}]}", "${trackingkey[${index_pkg}]}", "Post-modification script", "${package[${index_pkg}]}", "Execution of the post-modification script", "${index_pkg}"),
+                               ifvarclass => "posthook_specified_${index_pkg}.${inner_class_prefix}_repaired";
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/16849