### PR TITLE
Fixes #17481: when running cf-promises, list-compatible-inputs is ran 8 times

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -162,7 +162,10 @@ bundle common va
       "list_compatible_inputs" string => "C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -ExecutionPolicy Bypass -File '${ncf_path}\common\10_ncf_internals\list-compatible-inputs.ps1'";
       "compatible_inputs_cmd"  string => "${list_compatible_inputs} ${sys.cf_version} '${ncf_path}'";
 
-    any::
+    # prevent reevaluation of list-compatible-inputs command
+    # the list_compatible_inputs_ok is set in the classes part, meaning
+    # command has already been executed, for the better or worse
+    any.!list_compatible_inputs_ok::
       "raw_path_ncf_common_inputs" slist => splitstring(execresult("${compatible_inputs_cmd} common", "${shell_type}"), "\n", 10000);
       "raw_path_ncf_local_inputs"  slist => splitstring(execresult("${compatible_inputs_cmd} local", "${shell_type}"), "\n", 10000);
 
@@ -181,8 +184,7 @@ bundle common va
       # Need to remove cf_null from the list
       "ncf_inputs"            slist => filter("${ncf_path}/cf_null", "raw_ncf_inputs", "false", "true", 10000);
 
-    # create the final input list after ncf
-    any::
+      # create the final input list after ncf
       # all other inputs are loaded by body file control in rudder-system-directives.cf and rudder-directives.cf
       "inputs_list" slist => { @{ncf_inputs} };
 
@@ -199,6 +201,9 @@ bundle common va
       "SuSE" expression => "sles|opensuse";
       "suse" expression => "sles|opensuse";
       "redhat" expression => "amzn|amazon_linux";
+
+    # Define classes that policies are evaluable
+      "list_compatible_inputs_ok" expression => "any";
 
     # I don't know why, but these classes are not evaluated if they are in rudder_roles
       # Policy Server is a machine which delivers promises


### PR DESCRIPTION
https://issues.rudder.io/issues/17481