### PR TITLE
Fixes #18176: Technique shared folder on WIndows use invalid md5 hash instead of sha256

### DIFF
--- a/techniques/fileDistribution/copyGitFile/2.3/copyFileFromSharedFolder.ps1.st
+++ b/techniques/fileDistribution/copyGitFile/2.3/copyFileFromSharedFolder.ps1.st
@@ -25,7 +25,7 @@ function copyFileFromSharedFolder_RudderUniqueID {
     $SharedFiles   = "&SHARED_FILES_FOLDER&"
     $componentName = "Copy file"
     $postHookComponent = "Post-modification hook"
-    $HashCheckType = "md5"
+    $HashCheckType = "sha256"
     $local_classes = New-ClassContext
 
     for ($i=0; $i -lt $trackingkey.length; $i++) {


### PR DESCRIPTION
https://issues.rudder.io/issues/18176