### PR TITLE
Fixes #18279: When the database is not hosted on the rudder server itself, the configuration set by techniques is invalid

### DIFF
--- a/techniques/system/common/1.0/site.cf
+++ b/techniques/system/common/1.0/site.cf
@@ -84,14 +84,15 @@ bundle common g
 
   classes:
 
-    # Utilities
-    "gzip_installed"                 expression => isexecutable("${gzip}");
-    "curl_installed"                 expression => isexecutable("${rudder_curl}");
+      # Utilities
+      "gzip_installed"                 expression => isexecutable("${gzip}");
+      "curl_installed"                 expression => isexecutable("${rudder_curl}");
 
-    # Roles
-    "rudder_server_roles_dir_exists"       expression => isdir("${server_roles_path}");
-    "role_rudder_server_root"              expression => or(fileexists("${rudder_base}/etc/server-roles.d/rudder-server-root"), strcmp("${g.uuid}", "root"));
-    "role_rudder_webapp"                   expression => fileexists("${rudder_base}/etc/server-roles.d/rudder-webapp");
-    "role_rudder_reports"                  expression => fileexists("${rudder_base}/etc/server-roles.d/rudder-reports");
+      # Roles
+      "rudder_server_roles_dir_exists" expression => isdir("${server_roles_path}");
+    rudder_server_roles_dir_exists::
+      "role_rudder_server_root"        expression => fileexists("${server_roles_path}rudder-server-root");
+      "role_rudder_webapp"             expression => fileexists("${server_roles_path}rudder-webapp");
+      "role_rudder_reports"            expression => fileexists("${server_roles_path}rudder-reports");
 }
 

--- a/techniques/system/server-roles/1.0/component-check.cf
+++ b/techniques/system/server-roles/1.0/component-check.cf
@@ -31,8 +31,9 @@ bundle agent root_component_check
       "any" usebundle => rudder_generic_service_na("postgresql");
 
 
-    # This is to be done only if the package rudder-server-root is present
-    role_rudder_server_root::
+    # This is to be done only on the root server - package rudder-root-server is not
+    # enough as distributed database need to be configured
+    root_server::
       # Password management is expected to be done manually in case of a splitted/relayed installation for now.
       "any" usebundle => root_password_check_ldap;
       "any" usebundle => root_password_check_file;
@@ -40,7 +41,7 @@ bundle agent root_component_check
       "any" usebundle => root_password_security;
       "any" usebundle => root_password_restart_jetty;
 
-    !role_rudder_server_root::
+    !root_server::
       "any" usebundle => rudder_common_report("${technique_name}", "result_na", "${server_roles_common.directiveId}",
           "${root_password_check_ldap}", "None", "Checking LDAP passwords is unnecessary on this machine, skipping."
         );


### PR DESCRIPTION
https://issues.rudder.io/issues/18279