### PR TITLE
Fixes #19477: Policy validation at the end of policy generation spends too much time evaluating things

### DIFF
--- a/techniques/applications/repoGpgKeyManagement/1.1/repoGpgKeyManagement.st
+++ b/techniques/applications/repoGpgKeyManagement/1.1/repoGpgKeyManagement.st
@@ -35,7 +35,7 @@ bundle agent check_repo_gpg_key_&RudderUniqueID&
 
 &GPG_KEY_CONTENT:{content |"repo_gpg_content[&i&]" string => "&content&";
 }&
-
+    agent::
       "repo_gpg_hash_lc[${keyid}]" string => execresult("${paths.echo} ${repo_gpg_hash[${keyid}]} | ${paths.tr} \"[:upper:]\" \"[:lower:]\"","useshell"),
         comment => "We need lower case to query RPM and it's also used in the apt-based module for class definition.";
 

--- a/techniques/system/common/1.0/environment-variables.cf
+++ b/techniques/system/common/1.0/environment-variables.cf
@@ -3,6 +3,7 @@
 bundle agent get_environment_variables
 {
   vars:
+    agent::
       "env_vars_list_cmd" string => "awk 'BEGIN { for (k in ENVIRON) { print k }; }'";
       "env_vars" slist => splitstring( execresult("${env_vars_list_cmd}","useshell"), "\n" , 2000);
       "node.env[${env_vars}]" string => getenv( "${env_vars}", 5000);

--- a/techniques/system/common/1.0/hooks.cf
+++ b/techniques/system/common/1.0/hooks.cf
@@ -390,13 +390,13 @@ bundle agent runhook_sshKeyDistribution_pre_hook(json) {
 
       # get the home dir for each users
       # Only Linuxes (not Slackware), Solaris and FreeBSD support PAM/getent
-    pass1.(linux.!slackware)|solaris|freebsd::
+    pass1.agent.(linux.!slackware)|solaris|freebsd::
 
       "userdata_${c_data_userlist[${bundles}_${array[${bundles}]}]}"
         string  => execresult("/usr/bin/getent passwd ${data_userlist[${bundles}_${array[${bundles}]}]}", "noshell");
 
       # On systems without PAM, directly read entries from /etc/passwd instead (compatibility)
-    pass1.!((linux.!slackware)|solaris|freebsd)::
+    pass1.agent.!((linux.!slackware)|solaris|freebsd)::
 
       "userdata_${c_data_userlist[${bundles}_${array[${bundles}]}]}"
         string  => execresult("/usr/bin/grep ^${data_userlist[${bundles}_${array[${bundles}]}]}: /etc/passwd", "noshell");

--- a/techniques/system/server-roles/1.0/component-check.cf
+++ b/techniques/system/server-roles/1.0/component-check.cf
@@ -7,9 +7,9 @@ bundle agent root_component_check
       "apache_dist_specific_name"                      string => "httpd";
 
     # sles 12, sp1 and sp2 don't have by default a systemd postgresql
-    !(sles_12_0|sles_12_1|sles_12_2)::
+    agent.!(sles_12_0|sles_12_1|sles_12_2)::
       "postgresql_service_name" string => execresult("${paths.systemctl} --no-ask-password list-unit-files --type service | ${paths.awk} -F'.' '{print $1}' | ${paths.grep} -E \"^postgresql-?[0-9]*$\" | tail -n 1", "useshell");
-    sles_12_0|sles_12_1|sles_12_2::
+    agent.(sles_12_0|sles_12_1|sles_12_2)::
       "postgresql_service_name" string => execresult("chkconfig 2>/dev/null | ${paths.awk} '{ print $1 }' | ${paths.grep} 'postgresql' | tail -n 1", "useshell");
 
     any::

--- a/techniques/system/server-roles/1.0/password-check.cf
+++ b/techniques/system/server-roles/1.0/password-check.cf
@@ -10,7 +10,7 @@ bundle common p
 
   vars:
 
-    root_server::
+    root_server.agent::
 
       "root_home_path" string => execresult("/usr/bin/getent passwd root | cut -d: -f6", "useshell");
 
@@ -154,7 +154,7 @@ bundle agent root_password_check_psql
 
   classes:
 
-    root_server::
+    root_server.agent::
 
       "psql_cant_connect" not => returnszero("/usr/bin/psql --no-password --host localhost --username rudder --dbname rudder --quiet --output /dev/null --command 'select 1' 2> /dev/null","useshell");
 
@@ -218,7 +218,7 @@ bundle agent root_password_check_dav
       "rudder[rudder.webdav.password]" string => "${p.dav_password[2]}";
 
   classes:
-
+    agent::
       "dav_cant_connect" not => returnszero("${g.rudder_curl} --tlsv1.2 --proxy '' ${g.rudder_verify_certs_option} --silent --fail --output /dev/null --user ${g.davuser}:${g.davpw} --upload-file /opt/rudder/etc/uuid.hive https://localhost/inventory-updates/uuid.hive","noshell");
 
     any::

--- a/techniques/systemSettings/misc/genericCommandVariableDefinition/3.0/genericCommandVariableDefinition.st
+++ b/techniques/systemSettings/misc/genericCommandVariableDefinition/3.0/genericCommandVariableDefinition.st
@@ -1,7 +1,7 @@
 bundle common generic_cmd_var_def {
 
-	vars:
-
+  vars:
+    agent::
 &GENERIC_COMMAND_VARIABLE_NAME, GENERIC_COMMAND_VARIABLE_BINARY, GENERIC_COMMAND_VARIABLE_SHELL:{name, binary, shell |"&name&" string => execresult("&binary&", "&shell&");
 }&
 		

--- a/techniques/systemSettings/misc/variableFromJsonFile/2.0/variableFromJsonFile.st
+++ b/techniques/systemSettings/misc/variableFromJsonFile/2.0/variableFromJsonFile.st
@@ -35,7 +35,8 @@ bundle agent variable_from_json_file
     # string template implementation in the webapp
     "cmd" string => "/usr/bin/uniq << EOF ${const.n}&TRACKINGKEY:{piuuid |&piuuid&};separator="${const.n}"&${const.n}EOF${const.n}"; 
 
-    "long_keys" string => execresult("${cmd}", "useshell");
+    "long_keys" string => execresult("${cmd}", "useshell"),
+                    if => "agent";
     "long_keys_list" slist => splitstring("${long_keys}", "${const.n}", "999");
     "unique_keys[${variable_index}]" string => nth("long_keys_list", "${index_from_zero[${variable_index}]}");
 

--- a/techniques/systemSettings/remoteAccess/sshKeyDistribution/3.0/sshKeyDistribution.st
+++ b/techniques/systemSettings/remoteAccess/sshKeyDistribution/3.0/sshKeyDistribution.st
@@ -57,13 +57,13 @@ bundle agent check_ssh_key_distribution
 
 
     # Only Linuxes (not Slackware), Solaris and FreeBSD support PAM/getent
-    (linux.!slackware)|solaris|freebsd::
+    agent.((linux.!slackware)|solaris|freebsd)::
 
       "userdata_${sshkey_distribution_index}"
         string  => execresult("/usr/bin/getent passwd ${sshkey_distribution_name[${sshkey_distribution_index}]}", "noshell");
 
     # On systems without PAM, directly read entries from /etc/passwd instead (compatibility)
-    !((linux.!slackware)|solaris|freebsd)::
+    agent.!((linux.!slackware)|solaris|freebsd)::
 
       "userdata_${sshkey_distribution_index}"
         string  => execresult("/usr/bin/grep ^${sshkey_distribution_name[${sshkey_distribution_index}]}: /etc/passwd", "noshell");


### PR DESCRIPTION
https://issues.rudder.io/issues/19477

This PR doesn't do much, except preventing non-agent component (and most importantly cf-promises) from executing commands
Impact on a large server with 16 000 nodes is lowering the time spent validating the policies from 770s to 640s