### PR TITLE
Fixes #19548: Parent task did not force python version to generate the initial policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 all: initial-promises bootstrap-promises/rudder.json bootstrap-promises/promises.cf
 
 initial-promises: rudder-templates-cli.jar test
-	python generateInitialPolicies.py
+	python3 generateInitialPolicies.py
 	mkdir -p initial-promises/node-server/common/cron
 	mkdir -p initial-promises/node-server/common/utilities
 	touch initial-promises/rudder_expected_reports.csv


### PR DESCRIPTION
https://issues.rudder.io/issues/19548