### PR TITLE
Fixes #19553: Initial policies generator uses rmtree options that are only available for python 3.8+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 all: initial-promises bootstrap-promises/rudder.json bootstrap-promises/promises.cf
 
 initial-promises: rudder-templates-cli.jar test
-	python3 generateInitialPolicies.py
+	python3 generate_initial_policies.py
 	mkdir -p initial-promises/node-server/common/cron
 	mkdir -p initial-promises/node-server/common/utilities
 	touch initial-promises/rudder_expected_reports.csv


### PR DESCRIPTION
https://issues.rudder.io/issues/19553