### PR TITLE
Fixes #20382: rudder is restarted in first agent run after upgrade from 6.2 to 7.0

### DIFF
--- a/techniques/system/rudder-service-slapd/1.0/main.st
+++ b/techniques/system/rudder-service-slapd/1.0/main.st
@@ -56,5 +56,5 @@ bundle edit_line set_rudder_slapd_password(password) {
       "rootpw.*";
 
   insert_lines:
-      "rootpw  ${password}" location => after("^rootdn.*");
+      "rootpw         ${password}" location => after("^rootdn.*");
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/20382