### PR TITLE
Fixes #20792: When upgrading from 6.2 to 7.0, the previous rudder logrotate configuration is not removed

### DIFF
--- a/techniques/system/rudder-service-apache/1.0/apache/logrotate.cf
+++ b/techniques/system/rudder-service-apache/1.0/apache/logrotate.cf
@@ -18,6 +18,11 @@ bundle agent system_apache_logrotate {
       "pass1" expression => "any";
       "duration_configured" expression => isvariable("rudder_parameters.log_duration");
 
+  files:
+      "/etc/logrotate.d/rudder"
+        delete  => tidy,
+        comment => "Removing logrotate file from 6.x";
+
   methods:
     pass2::
       "any" usebundle => _method_reporting_context("Apache configuration", "Logrotate");

--- a/techniques/system/rudder-service-relayd/1.0/common/logrotate.cf
+++ b/techniques/system/rudder-service-relayd/1.0/common/logrotate.cf
@@ -26,6 +26,11 @@ bundle agent system_relay_logrotate {
       "pass1" expression => "any";
       "duration_configured" expression => isvariable("rudder_parameters.log_duration");
 
+  files:
+      "/etc/logrotate.d/rudder"
+        delete  => tidy,
+        comment => "Removing logrotate file from 6.x";
+
   methods:
     pass2::
       "any" usebundle => _method_reporting_context("Rudder-relayd service", "Log rotation");

--- a/techniques/system/rudder-service-slapd/1.0/logrotate.cf
+++ b/techniques/system/rudder-service-slapd/1.0/logrotate.cf
@@ -26,6 +26,10 @@ bundle agent system_slapd_logrotate {
       "pass1" expression => "any";
       "duration_configured" expression => isvariable("rudder_parameters.log_duration");
 
+  files:
+      "/etc/logrotate.d/rudder"
+        delete  => tidy,
+        comment => "Removing logrotate file from 6.x";
   methods:
     pass2::
       "any" usebundle => _method_reporting_context("Rudder slapd configuration", "Log rotation");


### PR DESCRIPTION
https://issues.rudder.io/issues/20792