### PR TITLE
Fixes #20993: When updating allowed networks of a relay, rudder-cf-serverd service does not seem to be restarted

### DIFF
--- a/techniques/system/common/1.0/common.st
+++ b/techniques/system/common/1.0/common.st
@@ -16,6 +16,8 @@ bundle common system_common {
     "heartbeat_interval"    string => "&RUDDER_HEARTBEAT_INTERVAL&";
     "rudder_node_config_id" string => "&RUDDER_NODE_CONFIG_ID&";
     "agent_run_interval"    string => "&AGENT_RUN_INTERVAL&";
+    
+    "cf_serverd_service_name" string => "rudder-cf-serverd";
 
   classes:
 &if(INITIAL)&

--- a/techniques/system/rudder-service-apache/1.0/apache/system_rudder_apache_webdav_configuration.cf
+++ b/techniques/system/rudder-service-apache/1.0/apache/system_rudder_apache_webdav_configuration.cf
@@ -41,8 +41,11 @@ bundle agent system_rudder_apache_webdav_configuration {
   classes:
       "dav_cant_connect" not => returnszero("${g.rudder_curl} --tlsv1.2 --proxy '' ${g.rudder_verify_certs_option} --silent --fail --output /dev/null --user ${system_common.davuser}:${webdav_password} --upload-file ${g.rudder_base}/etc/uuid.hive https://localhost:${system_rudder_apache_configuration.https_port}/inventory-updates/uuid.hive","noshell");
 
-      "rudder_server_system_reload_apache" expression => "${pwd_class_prefix}_repaired",
-                                                scope => "namespace";
+      "rudder_server_system_reload_apache"     expression => "${pwd_class_prefix}_repaired",
+                                                    scope => "namespace";
+      # we need to reload cf_serverd if the networks are changed
+      "rudder_server_system_reload_cf_serverd" expression => "${pwd_class_prefix}_repaired",
+                                                    scope => "namespace";
 
   methods:
       "any" usebundle => _method_reporting_context("${component}", "Webdav permissions");

--- a/techniques/system/server-common/1.0/reloadRudderServices.st
+++ b/techniques/system/server-common/1.0/reloadRudderServices.st
@@ -9,12 +9,15 @@ bundle agent system_reload_rudder_services {
       "apache_service_name" string => "${rudder_apache.service_name}";
       "relayd_service_name" string => "${rudder_relayd.service_name}";
       "slapd_service_name"  string => "${rudder_slapd.service_name}";
+      "cf_serverd_service_name" string => "${system_common.cf_serverd_service_name}";
 
       "jetty_prefix"          string => canonify("service_restart_${jetty_service_name}");
       "apache_reload_prefix"  string => canonify("service_reload_${apache_service_name}");
       "apache_restart_prefix" string => canonify("service_restart_${apache_service_name}");
       "relayd_reload_prefix"  string => canonify("service_reload_${relayd_service_name}");
       "relayd_restart_prefix" string => canonify("service_restart_${relayd_service_name}");
+      "cfserverd_reload_or_restart_prefix"
+                              string => canonify("service_action_${cf_serverd_service_name}");
       "slapd_prefix"          string => canonify("service_restart_${slapd_service_name}");
 
       "prefixes"              slist => {
@@ -23,6 +26,7 @@ bundle agent system_reload_rudder_services {
                                          "${apache_restart_prefix}",
                                          "${relayd_reload_prefix}",
                                          "${relayd_restart_prefix}",
+                                         "${cfserverd_reload_or_restart_prefix}",
                                          "${slapd_prefix}"
                                        };
 
@@ -56,6 +60,8 @@ bundle agent system_reload_rudder_services {
       "any" usebundle => service_reload("${relayd_service_name}");
     rudder_server_system_restart_relayd::
       "any" usebundle => service_restart("${relayd_service_name}");
+    rudder_server_system_reload_cf_serverd::
+      "any" usebundle => service_action("${cf_serverd_service_name}", "reload-or-restart");
     pass3::
       "any" usebundle => enable_reporting;
 


### PR DESCRIPTION
https://issues.rudder.io/issues/20993