### PR TITLE
Fixes #21122: Rudder server 7.X generates invalid configuration for 6.X relayd

### DIFF
--- a/techniques/system/rudder-service-relayd/1.0/common/relayd.conf.tpl
+++ b/techniques/system/rudder-service-relayd/1.0/common/relayd.conf.tpl
@@ -66,7 +66,13 @@ max_pool_size = 10
 {{/classes.root_server}}
 
 [output.upstream]
+# url in 6.X, host after
+{{#classes.cfengine_3_15}}
+url = "https://{{{vars.server_info.policy_server}}}"
+{{/classes.cfengine_3_15}}
+{{^classes.cfengine_3_15}}
 host = "{{{vars.server_info.policy_server}}}"
+{{/classes.cfengine_3_15}}
 user = "{{{vars.g.davuser}}}"
 password = "{{{vars.g.davpw}}}"
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21122