### PR TITLE
Fixes #21977:  Disable agent syslog logging by default - stay compatible with old agents

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -524,10 +524,11 @@ bundle common rudder_syslog_facility {
   vars:
 @if feature(syslog_disableable)
       "valid_values" slist => {"NONE", "LOG_USER", "LOG_DAEMON", "LOG_LOCAL0", "LOG_LOCAL1", "LOG_LOCAL2", "LOG_LOCAL3", "LOG_LOCAL4", "LOG_LOCAL5", "LOG_LOCAL6", "LOG_LOCAL7"};
+      "syslog"      string => "NONE";
 @else
       "valid_values" slist => {"LOG_USER", "LOG_DAEMON", "LOG_LOCAL0", "LOG_LOCAL1", "LOG_LOCAL2", "LOG_LOCAL3", "LOG_LOCAL4", "LOG_LOCAL5", "LOG_LOCAL6", "LOG_LOCAL7"};
+      "syslog"      string => "LOG_LOCAL3";
 @endif
-      "syslog"     string => "NONE";
 
     rudder_is_syslog_out_valid::
       "syslog" string => "${node.properties[rudder][log][syslog_facility]}";


### PR DESCRIPTION
https://issues.rudder.io/issues/21977