### PR TITLE
Fixes #23497: Prevent agents <6.0 from running on a 8.X server

### DIFF
--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -468,7 +468,7 @@ bundle agent update_reports
 bundle agent rudder_check_agent_version
 {
   methods:
-    cfengine_3_1|cfengine_3_2|cfengine_3_3|cfengine_3_4|cfengine_3_5|cfengine_3_6|cfengine_3_7|cfengine_3_8|cfengine_3_9|cfengine_3_10|cfengine_3_11|cfengine_3_12|cfengine_3_13|cfengine_3_14::
+    cfengine_3_1|cfengine_3_2|cfengine_3_3|cfengine_3_4|cfengine_3_5|cfengine_3_6|cfengine_3_7|cfengine_3_8|cfengine_3_9|cfengine_3_10|cfengine_3_11|cfengine_3_12|cfengine_3_13|cfengine_3_14|cfengine_3_15::
       "any" usebundle => _abort("unsupported_agent", "This agent is not compatible with its Rudder server, please upgrade");
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23497