### PR TITLE
Fixes #24448: Broken techniques qa-test

### DIFF
--- a/techniques/system/common/1.0/properties.cf
+++ b/techniques/system/common/1.0/properties.cf
@@ -70,10 +70,6 @@ bundle common properties
     "${autocond_properties}_items" slist => getindices("node.properties[${autocond_properties}]");
     "typeof_${autocond_properties}_${${autocond_properties}_items}" string => type("node.properties[${autocond_properties}][${${autocond_properties}_items}]", "true");
 
-  reports:
-    debug::
-      "typeof_${autocond_properties}_${${autocond_properties}_items}: '${typeof_${autocond_properties}_${${autocond_properties}_items}}'";
-
   classes:
     "is_boolean_${autocond_properties}_${${autocond_properties}_items}" expression => strcmp("data boolean", "${typeof_${autocond_properties}_${${autocond_properties}_items}}");
     "is_string_${autocond_properties}_${${autocond_properties}_items}"  expression => strcmp("data string",  "${typeof_${autocond_properties}_${${autocond_properties}_items}}");


### PR DESCRIPTION
https://issues.rudder.io/issues/24448

```
The file /home/amousset/projects/rudder-techniques/techniques/system/common/1.0/properties.cf
uses reports: instead of rudder_common_report
```