### PR TITLE
Fixes #24560: Add a unique component to inventory and inventory signature file name

### DIFF
--- a/techniques/system/inventory/1.0/fusionAgent.st
+++ b/techniques/system/inventory/1.0/fusionAgent.st
@@ -138,8 +138,12 @@ bundle agent download_server_uuid
 bundle agent fusionAgent
 {
   vars:
-    any::
-      "inventory_name"           string => "${sys.uqhost}-${g.uuid}.ocs";
+    !pass1::
+      # Add a unique value to allow matching inventory and signature files
+      "date"                     string => execresult("LANG=C /bin/date --utc --iso-8601=seconds", "useshell");
+      "inventory_name"           string => "${g.uuid}_${date}.ocs";
+      # Required when used in a regex
+      "inventory_name_esc"       string => escape("${inventory_name}");
       "inventory_path"           string => "${g.rudder_var_tmp}/inventory/${inventory_name}";
     verbose_inventory|verbose_mode::
       "inventory_opts"           string => "--debug --debug ";
@@ -276,20 +280,20 @@ bundle agent sendInventory
   files:
     !root_server.!have_client::
       # remove this when 6.2 agent are not supported anymore
-      "${g.rudder_inventories}/${fusionAgent.inventory_name}.*"
+      "${g.rudder_inventories}/${fusionAgent.inventory_name_esc}.*"
         transformer => "${g.rudder_curl} --tlsv1.2 --location ${g.rudder_verify_certs_option} --fail --silent --proxy '' --user ${g.davuser}:${g.davpw} --upload-file ${this.promiser} ${download_endpoint}",
         classes      => persistent_class("inventory_sent", "cant_send_inventory", "${min_resend_delay}"),
         comment      => "Sending the inventory to the server";
 
     !root_server.have_client::
-      "${g.rudder_inventories}/${fusionAgent.inventory_name}.*"
+      "${g.rudder_inventories}/${fusionAgent.inventory_name_esc}.*"
         transformer => "/opt/rudder/bin/rudder-client -e ${endpoint} -- --upload-file ${this.promiser}",
         classes      => persistent_class("inventory_sent", "cant_send_inventory", "${min_resend_delay}"),
         comment      => "Sending the inventory to the server";
 
     root_server::
       # minimal change to copy inventories to accepted node updates on root server
-      "${g.rudder_inventories}/${fusionAgent.inventory_name}\..*"
+      "${g.rudder_inventories}/${fusionAgent.inventory_name_esc}\..*"
         transformer => "${g.rudder_cp} ${this.promiser} ${g.rudder_inventories}/accepted-nodes-updates",
         classes      => persistent_class("inventory_sent", "cant_send_inventory", "${min_resend_delay}"),
         comment      => "Copying the inventory on root server";


### PR DESCRIPTION
https://issues.rudder.io/issues/24560

Add a UNIX timestamp to the file name, allows avoiding clashes (as long as there are only one inventory by second). It is possible easily because this file name is totally opaque to the whole chain from agent to server.

```
2024-03-21 14:08:33+0100 INFO  inventory-processing - Inventory 'root_2024-03-27T12:00:11+00:00.ocs' for node 'rudder-snapshot.normation.com' [root] (signature:certified) processed in 823 milliseconds
```