### PR TITLE
Fixes #25639: rudder-cf-serverd is not restarted properly after a change in authorized network on a relay

### DIFF
--- a/techniques/system/rudder-service-apache/1.0/apache/system_rudder_apache_networks_configuration.cf
+++ b/techniques/system/rudder-service-apache/1.0/apache/system_rudder_apache_networks_configuration.cf
@@ -56,6 +56,12 @@ bundle agent system_rudder_apache_networks_configuration {
       # Restart apache at the end of the technique if needed
       "rudder_server_system_reload_apache" expression => "${allowed_network_prefix}_repaired|${remote_run_prefix}_repaired",
                                                 scope => "namespace";
+      # Restart cf-serverd at the end of the technique if needed
+      # As allowed networks configuration for cf-serverd are done using string template in the cf file, it is
+      # quite hard to detect when a change of configuration occurred.
+      # Whenever apache allowed networks change, the cf-serverd configuration is assumed to have also changed
+      "rudder_server_system_reload_cf_serverd" expression => "${allowed_network_prefix}_repaired|${remote_run_prefix}_repaired",
+                                                scope => "namespace";
 
   methods:
       # Allowed networks


### PR DESCRIPTION
https://issues.rudder.io/issues/25639