### PR TITLE
Fixes #26935: “Users” standard technique causes “Missing report” on Windows

### DIFF
--- a/techniques/systemSettings/userManagement/userManagement/10/userManagement.ps1.st
+++ b/techniques/systemSettings/userManagement/userManagement/10/userManagement.ps1.st
@@ -100,7 +100,7 @@ function check_usergroup_user_parameters_&RudderUniqueID& {
     $null = Rudder-Report-NA @naParams -ComponentName 'User primary group'
     $null = Rudder-Report-NA @naParams -ComponentName 'User full name'
     $null = Rudder-Report-NA @naParams -ComponentName 'User default shell'
-    $null = Rudder-Report-NA @naParams -ComponentName 'Home Directory'
+    $null = Rudder-Report-NA @naParams -ComponentName 'Home directory'
     $null = Rudder-Report-NA @naParams -ComponentName 'User secondary groups'
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26935