### PR TITLE
Fixes #27254: Apache refuses to start when /var/rudder/lib/ssl/policy_server.pem is a symlink

### DIFF
--- a/techniques/system/rudder-service-relayd/1.0/common/relayd.cf
+++ b/techniques/system/rudder-service-relayd/1.0/common/relayd.cf
@@ -26,7 +26,7 @@ bundle agent system_rudder_relayd_configuration {
       "any" usebundle => system_relay_logrotate;
 
       "any" usebundle => _method_reporting_context("${component}", "Policy-server certificate");
-      "any" usebundle => file_copy_from_local_source("${sys.policy_entry_dirname}/certs/root", "${g.rudder_var}/lib/ssl/policy_server.pem");
+      "any" usebundle => file_copy_from_local_source("${sys.policy_entry_dirname}/certs/root.pem", "${g.rudder_var}/lib/ssl/policy_server.pem");
 
       "any" usebundle => _method_reporting_context("${component}", "Policy server certificate permissions");
       "any" usebundle => permissions("${g.rudder_var}/lib/ssl/policy_server.pem", "640", "root", "rudder");


### PR DESCRIPTION
https://issues.rudder.io/issues/27254