### PR TITLE
Fixes #27702: The `cf-serverd` unit masking is always repaired

### DIFF
--- a/techniques/system/common/1.0/cf-serverd.st
+++ b/techniques/system/common/1.0/cf-serverd.st
@@ -213,5 +213,5 @@ body report_data_select rudder_data_select_policy_hub
 bundle agent disable_cf_serverd {
   methods:
       "any" usebundle => service_stopped("rudder-cf-serverd");
-      "any" usebundle => service_action("rudder-cf-serverd", "mask");
+      "any" usebundle => service_disabled("rudder-cf-serverd");
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/27702

Disabling should be enough in this context.