### PR TITLE
Fixes #28777: Allow CFEngine protocol negociation to select the latest version

### DIFF
--- a/techniques/system/common/1.0/failsafe.st
+++ b/techniques/system/common/1.0/failsafe.st
@@ -12,7 +12,7 @@ body common control
         inputs             => { "common/1.0/common.cf", "common/1.0/update.cf" };
         output_prefix      => "rudder";
 
-        protocol_version   => "2";
+        protocol_version   => "latest";
 
         tls_min_version => "1.3";
 }

--- a/techniques/system/common/1.0/promises.st
+++ b/techniques/system/common/1.0/promises.st
@@ -48,7 +48,7 @@ bundle common rudder_roles
 body common control
 {
         output_prefix => "rudder";
-        protocol_version => "2";
+        protocol_version => "latest";
 
         inputs => {
           @{va.inputs_list},


### PR DESCRIPTION
https://issues.rudder.io/issues/28777

* Docs: https://docs.cfengine.com/docs/lts/reference/components/#protocol_version
* It [does not risk](https://github.com/cfengine/core/blob/1166bdcb56975c8b564150c472971674c8a5728f/libcfnet/tls_client.c#L220) downgrading below version `2` (TLS)
* The server has no setting and accepts all compatible versions, except that "classic" connections are refused if not explicitely authorized (with `allowlegacyconnects`)
* Wont break with older agents as the version is negociated
* Allows using the rsync-based copy on compatible agents+servers.