### PR TITLE
Fixes #29416: In technique packageManagement already_install class is defined in pass1

### DIFF
--- a/techniques/applications/packageManagement/1.3/packageManagement.st
+++ b/techniques/applications/packageManagement/1.3/packageManagement.st
@@ -102,8 +102,10 @@ bundle agent package_management_action_&RudderUniqueID&(package, state, version,
       "allow_unstrusted"       expression => strcmp("${manager_allow_untrusted}", "true");
       "manager_apt"            expression => strcmp("${manager}", "apt");
       "apt_allow_untrusted"    expression => "allow_unstrusted.((debian.!manager_specified)|manager_apt)";
-      "already_installed"      expression => "${inner_check_prefix}_kept";
-
+    
+    pass2::
+      "already_installed"      expression => "${inner_check_prefix}_kept",
+                                  comment => "${unique}";
   methods:
     pass2.!pass3::
       "${unique}" usebundle => _method_reporting_context_v4("Package", "${package}", "${inner_check_prefix}");


### PR DESCRIPTION
https://issues.rudder.io/issues/29416